### PR TITLE
Ignore compiled python stuff in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.log
 config.py
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
Ignore byte-compiled python stuff.
Taken from https://github.com/github/gitignore/blob/main/Python.gitignore