### PR TITLE
Allow for source inventory fields to have a value of zero

### DIFF
--- a/netbox_zabbix_sync.py
+++ b/netbox_zabbix_sync.py
@@ -410,7 +410,10 @@ class NetworkDevice():
                 for item in field_list:
                     value = value[item] if value else None
                 # Check if the result is usable and expected
-                if value and isinstance(value, int | float | str ):
+                # We want to apply any int or float 0 values, 
+                # even if python thinks those are empty.
+                if ((value and isinstance(value, int | float | str )) or
+                     (isinstance(value, int | float) and int(value) ==0)):
                     self.inventory[zbx_inv_field] = str(value)
                 elif not value:
                     # empty value should just be an empty string for API compatibility


### PR DESCRIPTION
Minor bug fix for float or int zero values in inventory fields so we can use literal 0 values in the fields.