### PR TITLE
Update README.py to reflect Netbox code change

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,8 @@ If you want to automatically create hostgroups then the create permission on hos
 To make the user experience easier you could add a custom link that redirects users to the Zabbix latest data.
 ```
 * Name: zabbix_latestData
-* Text: {% if obj.cf["zabbix_hostid"] %}Show host in Zabbix{% endif %}
-* URL: http://myzabbixserver.local/zabbix.php?action=latest.view&hostids[]={{ obj.cf["zabbix_hostid"] }}
+* Text: {% if object.cf["zabbix_hostid"] %}Show host in Zabbix{% endif %}
+* URL: http://myzabbixserver.local/zabbix.php?action=latest.view&hostids[]={{ object.cf["zabbix_hostid"] }}
 ```
 ## Running the script
 ```


### PR DESCRIPTION
Per Netbox readme: [https://github.com/netbox-community/netbox/releases/v3.5.0](https://github.com/netbox-community/netbox/releases/v3.5.0)

- "The obj context variable is no longer passed when rendering custom links: Use object instead."

The obj. reference in the README was updated to object.

The code snippet is working in our Netbox instance. 