### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ docker run -d -t -i -e ZABBIX_HOST='https://zabbix.local' \
 -e ZABBIX_TOKEN='othersecrettoken' \
 -e NETBOX_HOST='https://netbox.local' \
 -e NETBOX_TOKEN='secrettoken' \
---name netbox-zabbix-sync ghcr.io/TheNetworkGuy/netbox-zabbix-sync:latest
+--name netbox-zabbix-sync ghcr.io/thenetworkguy/netbox-zabbix-sync:main
 ```
 
 This should run a one-time sync, you can check the sync with `docker logs netbox-zabbix-sync`.


### PR DESCRIPTION
Reference to "latest" container label updated to "main". Also updated case on ghcr.io username, was causing errors for me on Bookworm with Docker 26.1.4:

docker: invalid reference format: repository name (TheNetworkGuy/netbox-zabbix-sync) must be lowercase.