### PR TITLE
Allow proxy null value

### DIFF
--- a/modules/device.py
+++ b/modules/device.py
@@ -371,10 +371,13 @@ class NetworkDevice():
         Sets proxy or proxy group if this
         value has been defined in config context
 
-        input: List of all proxies and proxy gorups in standardized format
+        input: List of all proxies and proxy groups in standardized format
         """
         # check if the key Zabbix is defined in the config context
         if not "zabbix" in self.nb.config_context:
+            return False
+        if ("proxy" in self.nb.config_context["zabbix"] and
+               not self.nb.config_context["zabbix"]["proxy"]):
             return False
         # Proxy group takes priority over a proxy due
         # to it being HA and therefore being more reliable


### PR DESCRIPTION
Currently, when specifying a `null` value for the Zabbix Proxy in the NetBox Config Context, the script tries to lookup a proxy with the name `None`:

```
2024-07-24 10:42:50,769 - Netbox-Zabbix-sync - WARNING - Device **redacted**: unable to find proxy None
```

This pull request stops the script from looking up proxy names when a `null` value is present.