### PR TITLE
Traversal fixes

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - dockertest
+      - testing
 #    tags: 
 #      - [0-9]+.*
 

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - dockertest
-      - testing
 #    tags: 
 #      - [0-9]+.*
 

--- a/modules/device.py
+++ b/modules/device.py
@@ -100,9 +100,11 @@ class PhysicalDevice():
     def set_hostgroup(self, hg_format, nb_site_groups, nb_regions):
         """Set the hostgroup for this device"""
         # Create new Hostgroup instance
-        hg = Hostgroup("dev", self.nb, self.nb_api_version)
-        # Set Hostgroup nesting options
-        hg.set_nesting(traverse_site_groups, traverse_regions, nb_site_groups, nb_regions)
+        hg = Hostgroup("dev", self.nb, self.nb_api_version, logger=self.logger,
+                       nested_sitegroup_flag=traverse_site_groups,
+                       nested_region_flag=traverse_regions, 
+                       nb_groups=nb_site_groups, 
+                       nb_regions=nb_regions)
         # Generate hostgroup based on hostgroup format
         self.hostgroup = hg.generate(hg_format)
 

--- a/modules/hostgroups.py
+++ b/modules/hostgroups.py
@@ -6,7 +6,9 @@ from modules.tools import build_path
 class Hostgroup():
     """Hostgroup class for devices and VM's
     Takes type (vm or dev) and NB object"""
-    def __init__(self, obj_type, nb_obj, version, logger=None):
+    def __init__(self, obj_type, nb_obj, version, logger=None,
+                 nested_sitegroup_flag=False, nested_region_flag=False,
+                 nb_regions=None, nb_groups=None):
         self.logger = logger if logger else getLogger(__name__)
         if obj_type not in ("vm", "dev"):
             msg = f"Unable to create hostgroup with type {type}"
@@ -17,7 +19,8 @@ class Hostgroup():
         self.name = self.nb.name
         self.nb_version = version
         # Used for nested data objects
-        self.nested_objects = {}
+        self.set_nesting(nested_sitegroup_flag, nested_region_flag,
+                         nb_groups, nb_regions)
         self._set_format_options()
 
     def __str__(self):

--- a/modules/virtual_machine.py
+++ b/modules/virtual_machine.py
@@ -27,8 +27,11 @@ class VirtualMachine(PhysicalDevice):
     def set_hostgroup(self, hg_format, nb_site_groups, nb_regions):
         """Set the hostgroup for this device"""
         # Create new Hostgroup instance
-        hg = Hostgroup("vm", self.nb, self.nb_api_version, logger=self.logger)
-        hg.set_nesting(traverse_site_groups, traverse_regions, nb_site_groups, nb_regions)
+        hg = Hostgroup("vm", self.nb, self.nb_api_version, logger=self.logger,
+                       nested_sitegroup_flag=traverse_site_groups,
+                       nested_region_flag=traverse_regions,
+                       nb_groups=nb_site_groups,
+                       nb_regions=nb_regions)
         # Generate hostgroup based on hostgroup format
         self.hostgroup = hg.generate(hg_format)
 


### PR DESCRIPTION
This is a PR to fix #87.
Nesting will now be set during Hostgroup initialization, preventing the need to perform `_set_format_options()` twice.

