### PR TITLE
fix: show exception when there's a connection error with NetBox

### DIFF
--- a/netbox_zabbix_sync.py
+++ b/netbox_zabbix_sync.py
@@ -90,8 +90,9 @@ def main(arguments):
     try:
         device_cfs = list(netbox.extras.custom_fields.filter(
             type="text", content_type_id=23))
-    except RequestsConnectionError:
+    except RequestsConnectionError as e:
         logger.error(f"Unable to connect to NetBox with URL {netbox_host}."
+                     f" Error is: {e}"
                      " Please check the URL and status of NetBox.")
         sys.exit(1)
     except NBRequestError as e:


### PR DESCRIPTION
Hi and thank you for that handy script.

Can we add a better error message when connection to NetBox fails ?

Initially had this
```
❯ python netbox_zabbix_sync.py --verbose
2025-01-30 17:30:28,884 - NetBox-Zabbix-sync - ERROR - Unable to connect to NetBox with URL https://XXXXXXXXXXX Please check the URL and status of NetBox.
```
But didn't help as the error was due to Self Signed certificate.
I don't find the current message helpful, why just not throw the exception ? 

With my change - It's now obvious what the issue is.
```
❯ python netbox_zabbix_sync.py --verbose
2025-01-30 17:37:10,104 - NetBox-Zabbix-sync - ERROR - Unable to connect to NetBox with URL https://XXXXXXXXX. Please check SSL errors:  HTTPSConnectionPool(host='XXXXXXX', port=443): Max retries exceeded with url: /api/extras/custom-fields/?type=text&content_type_id=23&limit=0 (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed certificate in certificate chain (_ssl.c:997)')))
```

We could also catch `SSLError` and have a specific `except` statement for it if you wish, but regardless, I think we should be verbose when hitting such errors.