### PR TITLE
feat: support overridable template contexts using dictionaries

### DIFF
--- a/modules/device.py
+++ b/modules/device.py
@@ -156,9 +156,15 @@ class PhysicalDevice():
             e = (f"Host {self.name}: Key 'templates' not found in config "
                  "context 'zabbix' for template lookup")
             raise TemplateError(e)
-        # Check if format is list or string.
+        # Check if format is list, dictionary or string.
         if isinstance(self.config_context["zabbix"]["templates"], str):
             return [self.config_context["zabbix"]["templates"]]
+        elif isinstance(self.config_context["zabbix"]["templates"], dict):
+            return [
+              template
+              for template, enabled in self.config_context["zabbix"]["templates"].items()
+              if enabled
+            ]
         return self.config_context["zabbix"]["templates"]
 
     def set_inventory(self, nbdevice):


### PR DESCRIPTION
Basically permits the use of the following merging strategies:

### Top context

```
{
  "zabbix": {
    "templates": {
      "template1": true,
      "template2": true
    }
  }
}
```

### Middle context

```
{
  "zabbix": {
    "templates": {
      "template1": false,
      "template3": true
    }
  }
}
```

### Local context

```
{
  "zabbix": {
    "templates": {
      "template2": false
    }
  }
}
```

### Resulting context

```
{
  "zabbix": {
    "templates": {
      "template1": false,
      "template2": false,
      "template3": true
    }
  }
}
```

### Zabbix templates

```
["template3"]
```