### PR TITLE
Fixes bug for hostgroups and removed default

### DIFF
--- a/modules/device.py
+++ b/modules/device.py
@@ -564,6 +564,9 @@ class PhysicalDevice:
         final_data = []
         # Check if the hostgroup is in a nested format and check each parent
         for hostgroup in self.hostgroups:
+            # Check if hostgroup is string. If Nonetype skip hostgroup
+            if not isinstance(hostgroup, str):
+                continue
             for pos in range(len(hostgroup.split("/"))):
                 zabbix_hg = hostgroup.rsplit("/", pos)[0]
                 if self.lookupZabbixHostgroup(hostgroups, zabbix_hg):

--- a/modules/hostgroups.py
+++ b/modules/hostgroups.py
@@ -108,11 +108,6 @@ class Hostgroup:
 
     def generate(self, hg_format=None):
         """Generate hostgroup based on a provided format"""
-        # Set format to default in case its not specified
-        if not hg_format:
-            hg_format = (
-                "site/manufacturer/role" if self.type == "dev" else "cluster/role"
-            )
         # Split all given names
         hg_output = []
         hg_items = hg_format.split("/")


### PR DESCRIPTION
Fixes bug when a hostgroup is not resolved to a correct value (for instance a role on a VM is optional) and removes default parameters from the hostgroup generation since the defaults are place in modules/config.py and will always be present.