### PR TITLE
Inherent site properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.log
 .venv
+.env
 config.py
 Pipfile
 Pipfile.lock

--- a/README.md
+++ b/README.md
@@ -289,6 +289,27 @@ hostgroup_format = "mycustomfieldname"
 NetBox-Zabbix-sync - ERROR - ESXI1 has no reliable hostgroup. This is most likely due to the use of custom fields that are empty.
 ```
 
+### Extended site properties
+
+By default, NetBox will only return the following properties under the 'site' key for a device:
+
+- site id
+- (api) url
+- display name
+- name
+- slug
+- description
+
+However, NetBox-Zabbix-Sync allows you to extend these site properties with the full site information
+so you can use this data in inventory fields, tags and usermacros.
+
+To enable this functionality, enable the following setting in your configuration file:
+
+`extended_site_properties = True`
+
+Keep in mind that enabling this option will increase the number of API calls to your NetBox instance, 
+this might impact performance on large syncs.
+
 ### Device status
 
 By setting a status on a NetBox device you determine how the host is added (or

--- a/config.py.example
+++ b/config.py.example
@@ -53,6 +53,12 @@ hostgroup_format = "site/manufacturer/role"
 traverse_regions = False
 traverse_site_groups = False
 
+## Extended site properteis
+# By default, NetBox will only return basic site info for any device or VM.
+# By setting `extended_site_properties` to True, the script will query NetBox for additiopnal site info.
+# Be aware that this will increase the number of API queries to NetBox.
+extended_site_properties = False
+
 ## Filtering
 # Custom device filter, variable must be present but can be left empty with no filtering.
 # A couple of examples:
@@ -87,8 +93,8 @@ device_inventory_map = { "asset_tag": "asset_tag",
                          "virtual_chassis/name": "chassis",
                          "status/label": "deployment_status",
                          "location/name": "location",
-                         "latitude": "location_lat",
-                         "longitude": "location_lon",
+                         "site/latitude": "location_lat",
+                         "site/longitude": "location_lon",
                          "comments": "notes",
                          "name": "name",
                          "rack/name": "site_rack",
@@ -112,19 +118,19 @@ usermacro_sync = False
 # device usermacro_map to map NetBox fields to usermacros.
 device_usermacro_map = {"serial": "{$HW_SERIAL}",
                         "role/name": "{$DEV_ROLE}",
-                        "url": "{$NB_URL}",
+                        "display_url": "{$NB_URL}",
                         "id": "{$NB_ID}"}
 
 # virtual machine usermacro_map to map NetBox fields to usermacros.
 vm_usermacro_map = {"memory": "{$TOTAL_MEMORY}",
                     "role/name": "{$DEV_ROLE}",
-                    "url": "{$NB_URL}",
+                    "display_url": "{$NB_URL}",
                     "id": "{$NB_ID}"}
 
 # To sync host tags to Zabbix, set to True.
 tag_sync = False
 
-# Setting tag_lower to True will lower capital letters ain tag names and values
+# Setting tag_lower to True will lower capital letters in tag names and values
 # This is more inline with the Zabbix way of working with tags.
 #
 # You can however set this to False to ensure capital letters are synced to Zabbix tags.
@@ -132,8 +138,6 @@ tag_lower = True
 
 # We can sync NetBox device/VM tags to Zabbix, but as NetBox tags don't follow the key/value
 # pattern, we need to specify a tag name to register the NetBox tags in Zabbix.
-#
-#
 # 
 # If tag_name is set to False, we won't sync NetBox device/VM tags to Zabbix.
 tag_name = 'NetBox'

--- a/config.py.example
+++ b/config.py.example
@@ -93,8 +93,8 @@ device_inventory_map = { "asset_tag": "asset_tag",
                          "virtual_chassis/name": "chassis",
                          "status/label": "deployment_status",
                          "location/name": "location",
-                         "site/latitude": "location_lat",
-                         "site/longitude": "location_lon",
+                         "latitude": "location_lat",
+                         "longitude": "location_lon",
                          "comments": "notes",
                          "name": "name",
                          "rack/name": "site_rack",
@@ -102,6 +102,8 @@ device_inventory_map = { "asset_tag": "asset_tag",
                          "device_type/model": "type",
                          "device_type/manufacturer/name": "vendor",
                          "oob_ip/address": "oob_ip" }
+# Replace latitude and longitude with site/latitude and and site/longitude to use
+# site geo data. Enable extended_site_properties for this to work!
 
 # We also support inventory mapping on Virtual Machines.
 vm_inventory_map = { "status/label": "deployment_status",

--- a/modules/config.py
+++ b/modules/config.py
@@ -31,6 +31,7 @@ DEFAULT_CONFIG = {
     "nb_vm_filter": {"name__n": "null"},
     "inventory_mode": "disabled",
     "inventory_sync": False,
+    "extended_site_properties": False,
     "device_inventory_map": {
         "asset_tag": "asset_tag",
         "virtual_chassis/name": "chassis",

--- a/modules/device.py
+++ b/modules/device.py
@@ -2,7 +2,6 @@
 """
 Device specific handeling for NetBox to Zabbix
 """
-from pprint import pprint
 
 from copy import deepcopy
 from logging import getLogger

--- a/modules/device.py
+++ b/modules/device.py
@@ -2,6 +2,7 @@
 """
 Device specific handeling for NetBox to Zabbix
 """
+from pprint import pprint
 
 from copy import deepcopy
 from logging import getLogger

--- a/netbox_zabbix_sync.py
+++ b/netbox_zabbix_sync.py
@@ -166,6 +166,9 @@ def main(arguments):
             # Check if a valid hostgroup has been found for this VM.
             if not vm.hostgroups:
                 continue
+            if config["extended_site_properties"] and nb_vm.site:
+                logger.debug("VM %s: extending site information.", vm.name)
+                vm.site=(convert_recordset(netbox.dcim.sites.filter(id=nb_vm.site.id)))
             vm.set_inventory(nb_vm)
             vm.set_usermacros()
             vm.set_tags()
@@ -238,6 +241,9 @@ def main(arguments):
                     device.name,
                 )
                 continue
+            if config["extended_site_properties"] and nb_device.site:
+                logger.debug("Device %s: extending site information.", device.name)
+                device.site=(convert_recordset(netbox.dcim.sites.filter(id=nb_device.site.id)))
             device.set_inventory(nb_device)
             device.set_usermacros()
             device.set_tags()


### PR DESCRIPTION
This PR add the option to extend site properties of a device or VM with the full list of site properties normally returned by the `api/dcim/sites/` API endpoint.

This will alllow users to use properties (including custom fields) from the site level in things like user macros, inventory fields and tags. One instance where this is useful, is to use site lat/long data as geo data in the host inventory as suggested in #117.
