### PR TITLE
🐛 Enforce tag list order before comparison

### DIFF
--- a/modules/device.py
+++ b/modules/device.py
@@ -869,8 +869,10 @@ class PhysicalDevice:
 
         # Check host tags
         if config["tag_sync"]:
-            if remove_duplicates(host["tags"], sortkey="tag") == remove_duplicates(
-                self.tags, sortkey="tag"
+            if remove_duplicates(
+                host["tags"], lambda tag: f"{tag['tag']}{tag['value']}"
+            ) == remove_duplicates(
+                self.tags, lambda tag: f"{tag['tag']}{tag['value']}"
             ):
                 self.logger.debug("Host %s: Tags in-sync.", self.name)
             else:

--- a/modules/device.py
+++ b/modules/device.py
@@ -869,7 +869,9 @@ class PhysicalDevice:
 
         # Check host tags
         if config["tag_sync"]:
-            if remove_duplicates(host["tags"], sortkey="tag") == self.tags:
+            if remove_duplicates(host["tags"], sortkey="tag") == remove_duplicates(
+                self.tags, sortkey="tag"
+            ):
                 self.logger.debug("Host %s: Tags in-sync.", self.name)
             else:
                 self.logger.info("Host %s: Tags OUT of sync.", self.name)

--- a/modules/tools.py
+++ b/modules/tools.py
@@ -1,7 +1,6 @@
 """A collection of tools used by several classes"""
 
 from typing import Any, Callable, Optional, overload
-from warnings import deprecated
 from modules.exceptions import HostgroupError
 
 
@@ -118,11 +117,14 @@ def remove_duplicates(
 
 
 @overload
-@deprecated("input_list should be of type list[dict[Any, Any]]")
 def remove_duplicates(
     input_list: dict[Any, Any],
     sortkey: Optional[str | Callable[[dict[str, Any]], str]] = None,
-): ...
+):
+    """
+    deprecated: input_list as dict is deprecated, use list of dicts instead
+    """
+    ...
 
 
 def remove_duplicates(

--- a/modules/tools.py
+++ b/modules/tools.py
@@ -1,5 +1,7 @@
 """A collection of tools used by several classes"""
 
+from typing import Any, Callable, Optional, overload
+from warnings import deprecated
 from modules.exceptions import HostgroupError
 
 
@@ -108,15 +110,40 @@ def field_mapper(host, mapper, nbdevice, logger):
     return data
 
 
-def remove_duplicates(input_list, sortkey=None):
+@overload
+def remove_duplicates(
+    input_list: list[dict[Any, Any]],
+    sortkey: Optional[str | Callable[[dict[str, Any]], str]] = None,
+): ...
+
+
+@overload
+@deprecated("input_list should be of type list[dict[Any, Any]]")
+def remove_duplicates(
+    input_list: dict[Any, Any],
+    sortkey: Optional[str | Callable[[dict[str, Any]], str]] = None,
+): ...
+
+
+def remove_duplicates(
+    input_list: list[dict[Any, Any]] | dict[Any, Any],
+    sortkey: Optional[str | Callable[[dict[str, Any]], str]] = None,
+):
     """
     Removes duplicate entries from a list and sorts the list
+
+    sortkey: Optional; key to sort the list on. Can be a string or a callable function.
     """
     output_list = []
     if isinstance(input_list, list):
         output_list = [dict(t) for t in {tuple(d.items()) for d in input_list}]
+
     if sortkey and isinstance(sortkey, str):
         output_list.sort(key=lambda x: x[sortkey])
+
+    elif sortkey and callable(sortkey):
+        output_list.sort(key=sortkey)
+
     return output_list
 
 

--- a/modules/tools.py
+++ b/modules/tools.py
@@ -124,7 +124,6 @@ def remove_duplicates(
     """
     deprecated: input_list as dict is deprecated, use list of dicts instead
     """
-    ...
 
 
 def remove_duplicates(


### PR DESCRIPTION
This PR enforces the list order for the other side of the tag comparison. Previously there was a slight change of the generated tag list being a different order and causing repeated synchronization of the tags. This more inline with the other comparison methods where both sides of the array are normally sorted, for instance in user macros and hostgroups.