### PR TITLE
🔧 Updated post create command to fully use uv environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,19 +4,14 @@
 	"name": "Python 3",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/python:3.14",
-
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pip3 install --user -r requirements.txt && pip3 install --user uv pylint pytest coverage pytest-cov && uv sync --dev"
-
+	"postCreateCommand": "pip install --user uv && uv sync --dev"
 	// Configure tool-specific properties.
 	// "customizations": {},
-
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pip install --user uv && uv sync --dev"
+	"postCreateCommand": "pip install --user uv && uv sync --frozen --dev"
 	// Configure tool-specific properties.
 	// "customizations": {},
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.


### PR DESCRIPTION
This PR aims to simplify the devcontainer installation by installing required packages using the existing `uv.lock` file. All required development packages should be added to the development dependencies inside of the `pyproject.toml` file. Using the pinned dependency versions from the `uv.lock` file which can be updated using `uv sync` and/or `uv sync --upgrade`

Please verify the behavior of the devcontainer as the project dependencies are now installed only inside of the virtual environment. Any cli commands should be run using `uv run` for them to run inside of the `venv`. Example: `uv run python3 -m my_module.cli_command` or `uv run ruff check .`