### PR TITLE
🔧 Specifically ignore assertion in tests instead of entire codebase

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,6 @@ ignore = [
     "PLR0915",
     # Ignore too many branches
     "PLR0912",
-    # Ignore use of assert
-    "S101",
 ]
 
 select = [
@@ -65,10 +63,12 @@ select = [
     "RUF",
 ]
 
-[dependency-groups]
-dev = [
-    "pytest>=9.0.2",
-    "pytest-cov>=7.0.0",
-    "ruff>=0.14.14",
-    "ty>=0.0.14",
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = [
+    # Ignore use of assert
+    "S101",
 ]
+
+
+[dependency-groups]
+dev = ["pytest>=9.0.2", "pytest-cov>=7.0.0", "ruff>=0.14.14", "ty>=0.0.14"]


### PR DESCRIPTION
Slightly improves linting behavior by only ignoring the use of `assert` in the tests directory instead of the entire codebase.