### PR TITLE
Fixed incorrect version

### DIFF
--- a/netbox_zabbix_sync/modules/cli.py
+++ b/netbox_zabbix_sync/modules/cli.py
@@ -166,7 +166,7 @@ def parse_cli():
         default=None,
     )
     parser.add_argument(
-        "--version", action="version", version="NetBox-Zabbix Sync 3.4.0"
+        "--version", action="version", version="NetBox-Zabbix Sync 4.0.1"
     )
 
     # ── Boolean config overrides ───────────────────────────────────────────────


### PR DESCRIPTION
This pull request updates the version information displayed by the CLI for the NetBox-Zabbix Sync tool. The change ensures users see the correct version when running the CLI.

* CLI version update:
  * Updated the `--version` argument in `netbox_zabbix_sync/modules/cli.py` to display "NetBox-Zabbix Sync 4.0.1" instead of "3.4.0".