### PR TITLE
🐛 Changed log directory to current working dir instead of project root

### DIFF
--- a/netbox_zabbix_sync/modules/logging.py
+++ b/netbox_zabbix_sync/modules/logging.py
@@ -21,9 +21,10 @@ def setup_logger():
     """
     # Set logging
     lgout = logging.StreamHandler()
-    # Logfile in the project root
-    project_root = path.dirname(path.dirname(path.realpath(__file__)))
-    logfile_path = path.join(project_root, "sync.log")
+
+    # Create log file in current working directory
+    working_dir = path.realpath(path.curdir)
+    logfile_path = path.join(working_dir, "sync.log")
     lgfile = logging.FileHandler(logfile_path)
 
     logging.basicConfig(


### PR DESCRIPTION
This PR changes the parent folder for the `sync.log` file to the current working directory instead of the relative path of the `logging.py` module file.

This is similar to the issue of reading the `setting.py` file out of the project directory, as the modules are now nested one folder deeper. However, placing the log file inside of the project dir would not work when the project is installed through pip, as this would place the log file in some `lib/python/site-packages` path. 

I think placing the log file in the current directory serves to be the post backwards compatible. But we might benefited of adding a configurable log file path.