### PR TITLE
Bug/log directory

### DIFF
--- a/netbox_zabbix_sync/modules/logging.py
+++ b/netbox_zabbix_sync/modules/logging.py
@@ -21,9 +21,10 @@ def setup_logger():
     """
     # Set logging
     lgout = logging.StreamHandler()
-    # Logfile in the project root
-    project_root = path.dirname(path.dirname(path.realpath(__file__)))
-    logfile_path = path.join(project_root, "sync.log")
+
+    # Create log file in current working directory
+    working_dir = path.realpath(path.curdir)
+    logfile_path = path.join(working_dir, "sync.log")
     lgfile = logging.FileHandler(logfile_path)
 
     logging.basicConfig(


### PR DESCRIPTION
This pull request updates the logging setup to change where the log file is created. Instead of placing `sync.log` in the project root directory, the log file will now be created in the current working directory.

Logging configuration:

* Updated the `setup_logger` function in `logging.py` to set the log file path to the current working directory instead of the project root.