### PR TITLE
V4.0.1

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -24,6 +24,11 @@ description_dt_format = "%Y-%m-%d %H:%M:%S"
 ## Enable clustering of devices with virtual chassis setup
 clustering = False
 
+## Extend Virtual Chassis Information
+# When set to True, the script will  pull extended virtual chassis information which is then available for use in usermacros, tags and inventory.
+# Be aware that this will increase the number of API queries to NetBox.
+extended_virtual_chassis = False
+
 ## Enable hostgroup generation. Requires permissions in Zabbix
 create_hostgroups = True
 

--- a/config.py.example
+++ b/config.py.example
@@ -25,7 +25,7 @@ description_dt_format = "%Y-%m-%d %H:%M:%S"
 clustering = False
 
 ## Extend Virtual Chassis Information
-# When set to True, the script will  pull extended virtual chassis information which is then available for use in usermacros, tags and inventory.
+# When set to True, the script will pull extended virtual chassis information which is then available for use in usermacros, tags and inventory.
 # Be aware that this will increase the number of API queries to NetBox.
 extended_virtual_chassis = False
 

--- a/netbox_zabbix_sync/modules/cli.py
+++ b/netbox_zabbix_sync/modules/cli.py
@@ -31,6 +31,10 @@ _BOOL_ARGS = [
         "extended_site_properties",
         "Fetch additional site info from NetBox (increases API queries).",
     ),
+    (
+        "extended_virtual_chassis",
+        "Fetch additional virtual chassis info from NetBox (increases API queries).",
+    ),
     ("inventory_sync", "Sync NetBox device properties to Zabbix inventory."),
     ("usermacro_sync", "Sync usermacros from NetBox to Zabbix."),
     ("tag_sync", "Sync host tags to Zabbix."),

--- a/netbox_zabbix_sync/modules/cli.py
+++ b/netbox_zabbix_sync/modules/cli.py
@@ -133,6 +133,7 @@ def main(arguments):
         zbx_token=zabbix_token,
     )
     syncer.start()
+    syncer.logout()
 
 
 def parse_cli():

--- a/netbox_zabbix_sync/modules/cli.py
+++ b/netbox_zabbix_sync/modules/cli.py
@@ -166,7 +166,7 @@ def parse_cli():
         default=None,
     )
     parser.add_argument(
-        "--version", action="version", version="NetBox-Zabbix Sync 3.4.0"
+        "--version", action="version", version="NetBox-Zabbix Sync 4.0.1"
     )
 
     # ── Boolean config overrides ───────────────────────────────────────────────

--- a/netbox_zabbix_sync/modules/core.py
+++ b/netbox_zabbix_sync/modules/core.py
@@ -2,6 +2,7 @@
 
 import ssl
 from os import environ
+from pprint import pformat
 from typing import Any
 
 from pynetbox import api as nbapi
@@ -282,12 +283,11 @@ class Sync:
                     continue
                 if self.config["extended_site_properties"] and nb_vm.site:
                     logger.debug("Host %s: extending site information.", vm.name)
-                    vm.site = convert_recordset(
-                        self.netbox.dcim.sites.filter(id=nb_vm.site.id)
-                    )
+                    nb_vm.site.full_details()
                 vm.set_inventory(nb_vm)
                 vm.set_usermacros()
                 vm.set_tags()
+                logger.debug("Host %s NetBox data: %s", vm.name, pformat(dict(nb_vm)))
                 # Checks if device is in cleanup state
                 if vm.status in self.config["zabbix_device_removal"]:
                     if vm.zabbix_id:
@@ -361,12 +361,11 @@ class Sync:
                     continue
                 if self.config["extended_site_properties"] and nb_device.site:
                     logger.debug("Host %s: extending site information.", device.name)
-                    device.site = convert_recordset(
-                        self.netbox.dcim.sites.filter(id=nb_device.site.id)
-                    )
+                    nb_device.site.full_details()
                 device.set_inventory(nb_device)
                 device.set_usermacros()
                 device.set_tags()
+                logger.debug("Host %s NetBox data: %s", device.name, pformat(dict(nb_device)))
                 # Checks if device is part of cluster.
                 # Requires clustering variable
                 if device.is_cluster() and self.config["clustering"]:

--- a/netbox_zabbix_sync/modules/core.py
+++ b/netbox_zabbix_sync/modules/core.py
@@ -49,6 +49,58 @@ class Sync:
 
         self.config: dict[str, Any] = combined_config
 
+    def _combine_filters(self, config_filter, method_filter):
+        """
+        Combine filters from config and method parameters.
+        Method parameters will overwrite config filters if there are overlaps.
+        """
+        # Check if method filter is provided,
+        # if not return config filter directly
+        combined_filter = config_filter.copy()
+        if method_filter:
+            combined_filter.update(method_filter)
+        return combined_filter
+
+    def _validate_netbox_token(self, token: str, nb_version: str) -> bool:
+        """Validate the format of the NetBox token based on the NetBox version.
+        :param token: The NetBox token to validate.
+        :param nb_version: The version of NetBox being used.
+        :return: True if the token format is valid for the given NetBox version, False otherwise.
+        """
+        support_token_url = (
+            "https://netboxlabs.com/docs/netbox/integrations/rest-api/#v1-and-v2-tokens"  # noqa: S105
+        )
+        token_prefix = "nbt_"  # noqa: S105
+        nb_v2_support_version = "4.5"
+        v2_token = bool(token.startswith(token_prefix) and "." in token)
+        v2_error_token = bool(token.startswith(token_prefix) and "." not in token)
+        # Check if the token is passed without a proper key.token format
+        if v2_error_token:
+            logger.error(
+                "It looks like an invalid v2 token was passed. For more info, see %s",
+                support_token_url,
+            )
+            return False
+        # Warning message for Netbox token v1 with Netbox v4.5 and higher
+        if not v2_token and nb_version >= nb_v2_support_version:
+            logger.warning(
+                "Using Netbox v1 token format. "
+                "Consider updating to a v2 token. For more info, see %s",
+                support_token_url,
+            )
+        elif v2_token and nb_version < nb_v2_support_version:
+            logger.error(
+                "Using Netbox v2 token format with Netbox version lower than 4.5. "
+                "Revert to v1 token or upgrade Netbox to 4.5 or higher. For more info, see %s",
+                support_token_url,
+            )
+            return False
+        elif v2_token and nb_version >= nb_v2_support_version:
+            logger.debug("Using NetBox v2 token format.")
+        else:
+            logger.debug("Using NetBox v1 token format.")
+        return True
+
     def connect(
         self, nb_host, nb_token, zbx_host, zbx_user=None, zbx_pass=None, zbx_token=None
     ):
@@ -117,47 +169,17 @@ class Sync:
             return False
         return True
 
-    def _validate_netbox_token(self, token: str, nb_version: str) -> bool:
-        """Validate the format of the NetBox token based on the NetBox version.
-        :param token: The NetBox token to validate.
-        :param nb_version: The version of NetBox being used.
-        :return: True if the token format is valid for the given NetBox version, False otherwise.
+    def logout(self):
         """
-        support_token_url = (
-            "https://netboxlabs.com/docs/netbox/integrations/rest-api/#v1-and-v2-tokens"  # noqa: S105
-        )
-        token_prefix = "nbt_"  # noqa: S105
-        nb_v2_support_version = "4.5"
-        v2_token = bool(token.startswith(token_prefix) and "." in token)
-        v2_error_token = bool(token.startswith(token_prefix) and "." not in token)
-        # Check if the token is passed without a proper key.token format
-        if v2_error_token:
-            logger.error(
-                "It looks like an invalid v2 token was passed. For more info, see %s",
-                support_token_url,
-            )
-            return False
-        # Warning message for Netbox token v1 with Netbox v4.5 and higher
-        if not v2_token and nb_version >= nb_v2_support_version:
-            logger.warning(
-                "Using Netbox v1 token format. "
-                "Consider updating to a v2 token. For more info, see %s",
-                support_token_url,
-            )
-        elif v2_token and nb_version < nb_v2_support_version:
-            logger.error(
-                "Using Netbox v2 token format with Netbox version lower than 4.5. "
-                "Revert to v1 token or upgrade Netbox to 4.5 or higher. For more info, see %s",
-                support_token_url,
-            )
-            return False
-        elif v2_token and nb_version >= nb_v2_support_version:
-            logger.debug("Using NetBox v2 token format.")
-        else:
-            logger.debug("Using NetBox v1 token format.")
-        return True
+        Logout from Zabbix API
+        """
+        if self.zabbix:
+            self.zabbix.logout()
+            logger.debug("Logged out from Zabbix API.")
+            return True
+        return False
 
-    def start(self):
+    def start(self, device_filter=None, vm_filter=None):
         """
         Run the NetBox to Zabbix sync process.
         """
@@ -196,15 +218,17 @@ class Sync:
         # Set API parameter mapping based on API version
         proxy_name = "host" if str(self.zabbix.version) < "7" else "name"
         # Get all Zabbix and NetBox data
-        netbox_devices = list(
-            self.netbox.dcim.devices.filter(**self.config["nb_device_filter"])
+        dev_filter_combined = self._combine_filters(
+            self.config["nb_device_filter"], device_filter
         )
+        netbox_devices = list(self.netbox.dcim.devices.filter(**dev_filter_combined))
         netbox_vms = []
         if self.config["sync_vms"]:
+            vm_filter_combined = self._combine_filters(
+                self.config["nb_vm_filter"], vm_filter
+            )
             netbox_vms = list(
-                self.netbox.virtualization.virtual_machines.filter(
-                    **self.config["nb_vm_filter"]
-                )
+                self.netbox.virtualization.virtual_machines.filter(**vm_filter_combined)
             )
         netbox_site_groups = convert_recordset(self.netbox.dcim.site_groups.all())
         netbox_regions = convert_recordset(self.netbox.dcim.regions.all())
@@ -401,5 +425,4 @@ class Sync:
                 )
             except SyncError:
                 pass
-        self.zabbix.logout()
         return True

--- a/netbox_zabbix_sync/modules/core.py
+++ b/netbox_zabbix_sync/modules/core.py
@@ -287,7 +287,11 @@ class Sync:
                 vm.set_inventory(nb_vm)
                 vm.set_usermacros()
                 vm.set_tags()
-                logger.debug("Host %s NetBox data: %s", vm.name, pformat(dict(nb_vm)))
+                logger.debug(
+                    "Host %s NetBox data: %s",
+                    vm.name,
+                    pformat(nb_vm if isinstance(nb_vm, dict) else dict(nb_vm)),
+                )
                 # Checks if device is in cleanup state
                 if vm.status in self.config["zabbix_device_removal"]:
                     if vm.zabbix_id:
@@ -365,8 +369,13 @@ class Sync:
                 device.set_inventory(nb_device)
                 device.set_usermacros()
                 device.set_tags()
+
                 logger.debug(
-                    "Host %s NetBox data: %s", device.name, pformat(dict(nb_device))
+                    "Host %s NetBox data: %s",
+                    device.name,
+                    pformat(
+                        nb_device if isinstance(nb_device, dict) else dict(nb_device)
+                    ),
                 )
                 # Checks if device is part of cluster.
                 # Requires clustering variable

--- a/netbox_zabbix_sync/modules/core.py
+++ b/netbox_zabbix_sync/modules/core.py
@@ -290,7 +290,7 @@ class Sync:
                 logger.debug(
                     "Host %s NetBox data: %s",
                     vm.name,
-                    pformat(nb_vm if isinstance(nb_vm, dict) else dict(nb_vm)),
+                    pformat(dict(nb_vm)),
                 )
                 # Checks if device is in cleanup state
                 if vm.status in self.config["zabbix_device_removal"]:
@@ -371,11 +371,7 @@ class Sync:
                 device.set_tags()
 
                 logger.debug(
-                    "Host %s NetBox data: %s",
-                    device.name,
-                    pformat(
-                        nb_device if isinstance(nb_device, dict) else dict(nb_device)
-                    ),
+                    "Host %s NetBox data: %s", device.name, pformat(dict(nb_device))
                 )
                 # Checks if device is part of cluster.
                 # Requires clustering variable

--- a/netbox_zabbix_sync/modules/core.py
+++ b/netbox_zabbix_sync/modules/core.py
@@ -365,7 +365,9 @@ class Sync:
                 device.set_inventory(nb_device)
                 device.set_usermacros()
                 device.set_tags()
-                logger.debug("Host %s NetBox data: %s", device.name, pformat(dict(nb_device)))
+                logger.debug(
+                    "Host %s NetBox data: %s", device.name, pformat(dict(nb_device))
+                )
                 # Checks if device is part of cluster.
                 # Requires clustering variable
                 if device.is_cluster() and self.config["clustering"]:

--- a/netbox_zabbix_sync/modules/core.py
+++ b/netbox_zabbix_sync/modules/core.py
@@ -366,6 +366,14 @@ class Sync:
                 if self.config["extended_site_properties"] and nb_device.site:
                     logger.debug("Host %s: extending site information.", device.name)
                     nb_device.site.full_details()
+                if (
+                    self.config["extended_virtual_chassis"]
+                    and nb_device.virtual_chassis
+                ):
+                    logger.debug(
+                        "Host %s: extending virtual chassis information.", device.name
+                    )
+                    nb_device.virtual_chassis.full_details()
                 device.set_inventory(nb_device)
                 device.set_usermacros()
                 device.set_tags()

--- a/netbox_zabbix_sync/modules/core.py
+++ b/netbox_zabbix_sync/modules/core.py
@@ -374,13 +374,18 @@ class Sync:
                         "Host %s: extending virtual chassis information.", device.name
                     )
                     nb_device.virtual_chassis.full_details()
-                device.set_inventory(nb_device)
-                device.set_usermacros()
-                device.set_tags()
+                    if "members" in dict(nb_device.virtual_chassis):
+                        for member in nb_device.virtual_chassis.members:
+                            member.full_details()
 
                 logger.debug(
                     "Host %s NetBox data: %s", device.name, pformat(dict(nb_device))
                 )
+
+                device.set_inventory(nb_device)
+                device.set_usermacros()
+                device.set_tags()
+
                 # Checks if device is part of cluster.
                 # Requires clustering variable
                 if device.is_cluster() and self.config["clustering"]:

--- a/netbox_zabbix_sync/modules/device.py
+++ b/netbox_zabbix_sync/modules/device.py
@@ -62,7 +62,6 @@ class PhysicalDevice:
         self.hostgroups = []
         self.hostgroup_type = "dev"
         self.tenant = nb.tenant
-        self.site = nb.site
         self.config_context = nb.config_context
         self.zbxproxy = None
         self.zabbix_state = 0

--- a/netbox_zabbix_sync/modules/logging.py
+++ b/netbox_zabbix_sync/modules/logging.py
@@ -21,9 +21,10 @@ def setup_logger():
     """
     # Set logging
     lgout = logging.StreamHandler()
-    # Logfile in the project root
-    project_root = path.dirname(path.dirname(path.realpath(__file__)))
-    logfile_path = path.join(project_root, "sync.log")
+
+    # Create log file in current working directory
+    working_dir = path.realpath(path.curdir)
+    logfile_path = path.join(working_dir, "sync.log")
     lgfile = logging.FileHandler(logfile_path)
 
     logging.basicConfig(

--- a/netbox_zabbix_sync/modules/settings.py
+++ b/netbox_zabbix_sync/modules/settings.py
@@ -35,6 +35,7 @@ DEFAULT_CONFIG = {
     "inventory_mode": "disabled",
     "inventory_sync": False,
     "extended_site_properties": False,
+    "extended_virtual_chassis": False,
     "device_inventory_map": {
         "asset_tag": "asset_tag",
         "virtual_chassis/name": "chassis",

--- a/netbox_zabbix_sync/modules/tools.py
+++ b/netbox_zabbix_sync/modules/tools.py
@@ -89,7 +89,7 @@ def field_mapper(host, mapper, nbdevice, logger):
         # Check if the result is usable and expected
         # We want to apply any int or float 0 values,
         # even if python thinks those are empty.
-        if (value and isinstance(value, int | float | str)) or (
+        if (value and isinstance(value, int | float | str | list | dict)) or (
             isinstance(value, int | float) and int(value) == 0
         ):
             data[zbx_field] = str(value)
@@ -102,7 +102,7 @@ def field_mapper(host, mapper, nbdevice, logger):
             )
             data[zbx_field] = ""
         else:
-            # Value is not a string or numeral, probably not what the user expected.
+            # Value is not of known type, probably not what the user expected.
             logger.info(
                 "Host %s: Lookup for '%s' returned an unexpected type: it will be skipped.",
                 host,

--- a/netbox_zabbix_sync/modules/usermacros.py
+++ b/netbox_zabbix_sync/modules/usermacros.py
@@ -98,6 +98,14 @@ class ZabbixUsermacros:
                 macro_name,
             )
             return False
+        if len(macro["value"])>2048:
+            self.logger.warning(
+                "Host %s: Usermacro %s has a value that is %s bytes which is too large, skipping.",
+                self.name,
+                macro_name,
+                len(macro["value"])
+            )
+            return False
         return macro
 
     def generate(self):

--- a/netbox_zabbix_sync/modules/usermacros.py
+++ b/netbox_zabbix_sync/modules/usermacros.py
@@ -7,6 +7,7 @@ from re import match
 
 from netbox_zabbix_sync.modules.tools import field_mapper, sanatize_log_output
 
+MAX_VALUE_SIZE=2048
 
 class ZabbixUsermacros:
     """Class that represents Zabbix usermacros."""
@@ -98,7 +99,7 @@ class ZabbixUsermacros:
                 macro_name,
             )
             return False
-        if len(macro["value"])>2048:
+        if len(macro["value"]) > MAX_VALUE_SIZE:
             self.logger.warning(
                 "Host %s: Usermacro %s has a value that is %s bytes which is too large, skipping.",
                 self.name,

--- a/netbox_zabbix_sync/modules/usermacros.py
+++ b/netbox_zabbix_sync/modules/usermacros.py
@@ -7,7 +7,8 @@ from re import match
 
 from netbox_zabbix_sync.modules.tools import field_mapper, sanatize_log_output
 
-MAX_VALUE_SIZE=2048
+MAX_VALUE_SIZE = 2048
+
 
 class ZabbixUsermacros:
     """Class that represents Zabbix usermacros."""
@@ -104,7 +105,7 @@ class ZabbixUsermacros:
                 "Host %s: Usermacro %s has a value that is %s bytes which is too large, skipping.",
                 self.name,
                 macro_name,
-                len(macro["value"])
+                len(macro["value"]),
             )
             return False
         return macro

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1535,3 +1535,258 @@ class TestVMStatusHandling(unittest.TestCase):
         syncer.start()
 
         mock_zabbix.host.update.assert_called_once_with(hostid=42, status="1")
+
+
+class TestCombineFilters(unittest.TestCase):
+    """Test the _combine_filters method and filter override behavior in start()."""
+
+    def _setup_netbox_mock(self, mock_api, devices=None, vms=None):
+        """Helper to setup a working NetBox mock."""
+        mock_netbox = MagicMock()
+        mock_api.return_value = mock_netbox
+        mock_netbox.version = "3.5"
+        mock_netbox.extras.custom_fields.filter.return_value = []
+        mock_netbox.dcim.devices.filter.return_value = devices or []
+        mock_netbox.virtualization.virtual_machines.filter.return_value = vms or []
+        mock_netbox.dcim.site_groups.all.return_value = []
+        mock_netbox.dcim.regions.all.return_value = []
+        mock_netbox.extras.journal_entries = MagicMock()
+        return mock_netbox
+
+    def _setup_zabbix_mock(self, mock_zabbix_api, version="7.0"):
+        """Helper to setup a working Zabbix mock."""
+        mock_zabbix = MagicMock()
+        mock_zabbix_api.return_value = mock_zabbix
+        # Set version as float to match expected type in device.py comparisons
+        mock_zabbix.version = float(version)
+        mock_zabbix.hostgroup.get.return_value = [{"groupid": "1", "name": "TestGroup"}]
+        mock_zabbix.template.get.return_value = [
+            {"templateid": "1", "name": "TestTemplate"}
+        ]
+        mock_zabbix.proxy.get.return_value = []
+        mock_zabbix.proxygroup.get.return_value = []
+        mock_zabbix.host.get.return_value = []
+        mock_zabbix.host.create.return_value = {"hostids": ["1"]}
+        return mock_zabbix
+
+    @patch("netbox_zabbix_sync.modules.core.ZabbixAPI")
+    @patch("netbox_zabbix_sync.modules.core.nbapi")
+    def test_filter_override_with_name_parameter(self, mock_api, mock_zabbix_api):
+        """Test that method filter parameter overrides config filter for name.
+
+        Scenario:
+        - Config has nb_device_filter with name="SW01N0"
+        - start() is called with device_filter {"name": "Testdev02"}
+        - Only the device matching "Testdev02" should be processed
+        """
+        # Create two mock devices
+        device_matching_method_filter = MockNetboxDevice(
+            device_id=1, name="Testdev02", status_label="Active"
+        )
+        device_matching_config_filter = MockNetboxDevice(
+            device_id=2, name="SW01N0", status_label="Active"
+        )
+
+        # Setup mocks - the filter should be called with the combined/overridden filter
+        self._setup_netbox_mock(
+            mock_api,
+            devices=[
+                device_matching_method_filter,
+                device_matching_config_filter,
+            ],
+        )
+        self._setup_zabbix_mock(mock_zabbix_api)
+
+        # Create sync with config filter specifying one name
+        syncer = Sync({"nb_device_filter": {"name": "SW01N0"}})
+        syncer.connect(
+            "http://netbox.local",
+            "nb_token",
+            "http://zabbix.local",
+            "user",
+            "pass",
+            None,
+        )
+
+        # Call start with method filter specifying a different name
+        # The method filter should override the config filter
+        syncer.start(device_filter={"name": "Testdev02"})
+
+        # Verify that nbapi.dcim.devices.filter was called with the override filter
+        mock_netbox = mock_api.return_value
+        filter_call_kwargs = mock_netbox.dcim.devices.filter.call_args[1]
+        self.assertEqual(filter_call_kwargs.get("name"), "Testdev02")
+
+    @patch("netbox_zabbix_sync.modules.core.ZabbixAPI")
+    @patch("netbox_zabbix_sync.modules.core.nbapi")
+    def test_filter_override_site_parameter(self, mock_api, mock_zabbix_api):
+        """Test that site filter override works correctly.
+
+        Scenario:
+        - Config has no device filter set
+        - start() is called with device_filter {"site": "fra01"}
+        - Only devices in fra01 site should be processed
+        """
+        # Create mock sites
+        site_fra01 = MagicMock()
+        site_fra01.name = "fra01"
+        site_fra01.slug = "fra01"
+
+        site_ams01 = MagicMock()
+        site_ams01.name = "ams01"
+        site_ams01.slug = "ams01"
+
+        # Create devices in different sites
+        device_fra01 = MockNetboxDevice(
+            device_id=1, name="device-fra01", status_label="Active", site=site_fra01
+        )
+        device_ams01 = MockNetboxDevice(
+            device_id=2, name="device-ams01", status_label="Active", site=site_ams01
+        )
+
+        self._setup_netbox_mock(mock_api, devices=[device_fra01, device_ams01])
+        self._setup_zabbix_mock(mock_zabbix_api)
+
+        syncer = Sync()
+        syncer.connect(
+            "http://netbox.local",
+            "nb_token",
+            "http://zabbix.local",
+            "user",
+            "pass",
+            None,
+        )
+
+        # Call start with site filter for fra01
+        syncer.start(device_filter={"site": "fra01"})
+
+        # Verify that nbapi.dcim.devices.filter was called with the site filter
+        mock_netbox = mock_api.return_value
+        filter_call_kwargs = mock_netbox.dcim.devices.filter.call_args[1]
+        self.assertEqual(filter_call_kwargs.get("site"), "fra01")
+
+    @patch("netbox_zabbix_sync.modules.core.ZabbixAPI")
+    @patch("netbox_zabbix_sync.modules.core.nbapi")
+    def test_config_filter_overridden_by_start_parameter(
+        self, mock_api, mock_zabbix_api
+    ):
+        """Test that start() method filter overrides config filter.
+
+        Scenario:
+        - Config specifies nb_device_filter with {"name": "SW01N0", "site": "ams01"}
+        - start() is called with {"name": "Testdev02"} (only overriding name)
+        - The final filter should be {"name": "Testdev02", "site": "ams01"}
+        - Both name and site filters should be applied with the override
+        """
+        device_matching_all = MockNetboxDevice(
+            device_id=1, name="Testdev02", status_label="Active"
+        )
+
+        self._setup_netbox_mock(mock_api, devices=[device_matching_all])
+        self._setup_zabbix_mock(mock_zabbix_api)
+
+        # Create sync with config filter having multiple parameters
+        syncer = Sync({"nb_device_filter": {"name": "SW01N0", "site": "ams01"}})
+        syncer.connect(
+            "http://netbox.local",
+            "nb_token",
+            "http://zabbix.local",
+            "user",
+            "pass",
+            None,
+        )
+
+        # Call start with method filter that overrides only the name
+        syncer.start(device_filter={"name": "Testdev02"})
+
+        # Verify that nbapi.dcim.devices.filter was called with combined filter
+        # (site from config + name from method parameter)
+        mock_netbox = mock_api.return_value
+        filter_call_kwargs = mock_netbox.dcim.devices.filter.call_args[1]
+        self.assertEqual(filter_call_kwargs.get("name"), "Testdev02")
+        self.assertEqual(filter_call_kwargs.get("site"), "ams01")
+
+    @patch("netbox_zabbix_sync.modules.core.ZabbixAPI")
+    @patch("netbox_zabbix_sync.modules.core.nbapi")
+    def test_vm_filter_override_with_method_parameter(self, mock_api, mock_zabbix_api):
+        """Test that VM filter override works correctly.
+
+        Scenario:
+        - Config enables VM sync with nb_vm_filter {"name": "vm-prod"}
+        - start() is called with vm_filter {"name": "vm-test"}
+        - Only VMs matching "vm-test" should be processed
+        """
+        # Create two mock VMs
+        vm_matching_method_filter = MockNetboxVM(
+            vm_id=1, name="vm-test", status_label="Active"
+        )
+        vm_matching_config_filter = MockNetboxVM(
+            vm_id=2, name="vm-prod", status_label="Active"
+        )
+
+        self._setup_netbox_mock(
+            mock_api,
+            vms=[vm_matching_method_filter, vm_matching_config_filter],
+        )
+        self._setup_zabbix_mock(mock_zabbix_api)
+
+        # Create sync with config filter for VMs
+        syncer = Sync(
+            {
+                "sync_vms": True,
+                "nb_vm_filter": {"name": "vm-prod"},
+            }
+        )
+        syncer.connect(
+            "http://netbox.local",
+            "nb_token",
+            "http://zabbix.local",
+            "user",
+            "pass",
+            None,
+        )
+
+        # Call start with method filter that overrides the VM name filter
+        syncer.start(vm_filter={"name": "vm-test"})
+
+        # Verify that nbapi.virtualization.virtual_machines.filter was called with override
+        mock_netbox = mock_api.return_value
+        filter_call_kwargs = (
+            mock_netbox.virtualization.virtual_machines.filter.call_args[1]
+        )
+        self.assertEqual(filter_call_kwargs.get("name"), "vm-test")
+
+    @patch("netbox_zabbix_sync.modules.core.ZabbixAPI")
+    @patch("netbox_zabbix_sync.modules.core.nbapi")
+    def test_multiple_filter_parameters_combined(self, mock_api, mock_zabbix_api):
+        """Test that multiple filter parameters are correctly combined.
+
+        Scenario:
+        - Config has nb_device_filter with {"site": "fra01", "status": "active"}
+        - start() is called with {"name": "router*"}
+        - The final filter should have all three parameters
+        """
+        device = MockNetboxDevice(device_id=1, name="router01", status_label="Active")
+
+        self._setup_netbox_mock(mock_api, devices=[device])
+        self._setup_zabbix_mock(mock_zabbix_api)
+
+        syncer = Sync({"nb_device_filter": {"site": "fra01", "status": "active"}})
+        syncer.connect(
+            "http://netbox.local",
+            "nb_token",
+            "http://zabbix.local",
+            "user",
+            "pass",
+            None,
+        )
+
+        syncer.start(device_filter={"name": "router*"})
+
+        mock_netbox = mock_api.return_value
+        filter_call_kwargs = mock_netbox.dcim.devices.filter.call_args[1]
+
+        # All three parameters should be present
+        self.assertEqual(filter_call_kwargs.get("site"), "fra01")
+        self.assertEqual(filter_call_kwargs.get("status"), "active")
+        self.assertEqual(filter_call_kwargs.get("name"), "router*")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -663,49 +663,6 @@ class TestSyncZabbixVersionHandling(unittest.TestCase):
         mock_zabbix.proxygroup.get.assert_not_called()
 
 
-class TestSyncLogout(unittest.TestCase):
-    """Test that sync properly logs out from Zabbix."""
-
-    def _setup_netbox_mock(self, mock_api):
-        """Helper to setup a working NetBox mock."""
-        mock_netbox = MagicMock()
-        mock_api.return_value = mock_netbox
-        mock_netbox.version = "3.5"
-        mock_netbox.extras.custom_fields.filter.return_value = []
-        mock_netbox.dcim.devices.filter.return_value = []
-        mock_netbox.virtualization.virtual_machines.filter.return_value = []
-        mock_netbox.dcim.site_groups.all.return_value = []
-        mock_netbox.dcim.regions.all.return_value = []
-        return mock_netbox
-
-    @patch("netbox_zabbix_sync.modules.core.ZabbixAPI")
-    @patch("netbox_zabbix_sync.modules.core.nbapi")
-    def test_sync_logs_out_from_zabbix(self, mock_api, mock_zabbix_api):
-        """Test that sync calls logout on Zabbix API after completion."""
-        self._setup_netbox_mock(mock_api)
-
-        mock_zabbix = MagicMock()
-        mock_zabbix_api.return_value = mock_zabbix
-        mock_zabbix.version = "6.0"
-        mock_zabbix.hostgroup.get.return_value = []
-        mock_zabbix.template.get.return_value = []
-        mock_zabbix.proxy.get.return_value = []
-
-        syncer = Sync()
-        syncer.connect(
-            "http://netbox.local",
-            "nb_token",
-            "http://zabbix.local",
-            "user",
-            "pass",
-            None,
-        )
-        syncer.start()
-
-        # Verify logout was called
-        mock_zabbix.logout.assert_called_once()
-
-
 class TestSyncProxyNameSanitization(unittest.TestCase):
     """Test proxy name field sanitization for Zabbix 6."""
 
@@ -791,7 +748,6 @@ class TestDeviceHandeling(unittest.TestCase):
         ]
         mock_zabbix.proxy.get.return_value = []
         mock_zabbix.proxygroup.get.return_value = []
-        mock_zabbix.logout = MagicMock()
         # Mock host.get to return empty (host doesn't exist yet)
         mock_zabbix.host.get.return_value = []
         # Mock host.create to return success
@@ -1030,7 +986,6 @@ class TestDeviceStatusHandling(unittest.TestCase):
         ]
         mock_zabbix.proxy.get.return_value = []
         mock_zabbix.proxygroup.get.return_value = []
-        mock_zabbix.logout = MagicMock()
         mock_zabbix.host.get.return_value = []
         mock_zabbix.host.create.return_value = {"hostids": ["1"]}
         mock_zabbix.host.update.return_value = {"hostids": ["42"]}
@@ -1335,7 +1290,6 @@ class TestVMStatusHandling(unittest.TestCase):
         ]
         mock_zabbix.proxy.get.return_value = []
         mock_zabbix.proxygroup.get.return_value = []
-        mock_zabbix.logout = MagicMock()
         mock_zabbix.host.get.return_value = []
         mock_zabbix.host.create.return_value = {"hostids": ["1"]}
         mock_zabbix.host.update.return_value = {"hostids": ["42"]}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -10,7 +10,81 @@ from zabbix_utils import APIRequestError
 from netbox_zabbix_sync.modules.core import Sync
 
 
-class MockNetboxDevice:
+class MockListObject:
+    def __repr__(self):
+        return str(self.object)
+
+    def serialize(self):
+        ret = {k: getattr(self, k) for k in ["object_id", "object_type"]}
+        return ret
+
+    def __getattr__(self, k):
+        return getattr(self.object, k)
+
+    def __iter__(self):
+        for i in ["object_id", "object_type", "object"]:
+            cur_attr = getattr(self, i)
+            if isinstance(cur_attr, MockRecord):
+                cur_attr = dict(cur_attr)
+            yield i, cur_attr
+
+
+class MockRecord:
+    def __init__(self, values, api, endpoint):
+        self.has_details = False
+        self._full_cache = []
+        self._init_cache = []
+        self.api = api
+        self.default_ret = MockRecord
+
+    def __iter__(self):
+        for i in dict(self._init_cache):
+            cur_attr = getattr(self, i)
+            if isinstance(cur_attr, MockRecord):
+                yield i, dict(cur_attr)
+            elif isinstance(cur_attr, list) and all(
+                isinstance(i, (MockRecord, MockListObject)) for i in cur_attr
+            ):
+                yield i, [dict(x) for x in cur_attr]
+            else:
+                yield i, cur_attr
+
+    def __getitem__(self, k):
+        return dict(self)[k]
+
+    def __str__(self):
+        return (
+            getattr(self, "name", None)
+            or getattr(self, "label", None)
+            or getattr(self, "display", None)
+            or ""
+        )
+
+    def __repr__(self):
+        return str(self)
+
+    def __getstate__(self):
+        return self.__dict__
+
+    def __setstate__(self, d):
+        self.__dict__.update(d)
+
+    def __key__(self):
+        if hasattr(self, "id"):
+            return ("mock", self.id)
+        else:
+            return "mock"
+
+    def __hash__(self):
+        return hash(self.__key__())
+
+    def __eq__(self, other):
+        if isinstance(other, MockRecord):
+            return self.__key__() == other.__key__()
+        return NotImplemented
+
+
+class MockNetboxDevice(MockRecord):
     """Mock NetBox device object."""
 
     def __init__(
@@ -31,6 +105,7 @@ class MockNetboxDevice:
         serial="",
         tags=None,
     ):
+        super().__init__(values={}, api=None, endpoint=None)
         self.id = device_id
         self.name = name
         self.status = MagicMock()
@@ -108,7 +183,7 @@ class MockNetboxDevice:
         """Mock save method for NetBox device."""
 
 
-class MockNetboxVM:
+class MockNetboxVM(MockRecord):
     """Mock NetBox virtual machine object.
 
     Mirrors the real NetBox API response structure so the full VirtualMachine
@@ -130,6 +205,7 @@ class MockNetboxVM:
         platform=None,
         tags=None,
     ):
+        super().__init__(values={}, api=None, endpoint=None)
         self.id = vm_id
         self.name = name
         self.status = MagicMock()


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the NetBox-Zabbix sync tool, focusing on improved extensibility, better handling of virtual chassis and site information, logging improvements, and codebase maintainability. The most significant changes are the addition of extended virtual chassis support, improved filtering logic, and more robust logging and test utilities.

This PR will implement / fix the following issues: #180, #177, #176, #169

**Feature Enhancements:**

* Added support for fetching extended virtual chassis information from NetBox, controlled by the new `extended_virtual_chassis` configuration option and CLI flag. This allows for deeper integration and richer data synchronization, though it increases API queries. (`config.py.example`, `netbox_zabbix_sync/modules/cli.py`, `netbox_zabbix_sync/modules/core.py`, `netbox_zabbix_sync/modules/settings.py`) [[1]](diffhunk://#diff-d81370c2aa8ae22f210cdf48c95702f98326a198e9ddad046fc02ddd5e65159aR27-R31) [[2]](diffhunk://#diff-fe184527e0c6b2d7b25b220a6914f9678aa795f47e2381bfbd68af724b21068bR34-R37) [[3]](diffhunk://#diff-97e9516cf589a2d6488c85de1d781390896bf190b38e224cf7b5094a743b73b9R38) [[4]](diffhunk://#diff-ade8b735e1555be949f85a6868a642e45b0b1a02f1d8355dff07741f758e2bfdL340-R388)
* Improved device and VM filtering by introducing a `_combine_filters` method, allowing method-level filters to override configuration filters for more flexible data selection. (`netbox_zabbix_sync/modules/core.py`) [[1]](diffhunk://#diff-ade8b735e1555be949f85a6868a642e45b0b1a02f1d8355dff07741f758e2bfdR53-R104) [[2]](diffhunk://#diff-ade8b735e1555be949f85a6868a642e45b0b1a02f1d8355dff07741f758e2bfdL199-R232)

**Logging and Usability:**

* Changed log file location to the current working directory instead of the project root, making logs easier to find in typical deployment scenarios. (`netbox_zabbix_sync/modules/logging.py`)
* Added detailed debug logging of NetBox device and VM data using `pformat` for easier troubleshooting and visibility into the sync process. (`netbox_zabbix_sync/modules/core.py`) [[1]](diffhunk://#diff-ade8b735e1555be949f85a6868a642e45b0b1a02f1d8355dff07741f758e2bfdR5) [[2]](diffhunk://#diff-ade8b735e1555be949f85a6868a642e45b0b1a02f1d8355dff07741f758e2bfdL261-R294) [[3]](diffhunk://#diff-ade8b735e1555be949f85a6868a642e45b0b1a02f1d8355dff07741f758e2bfdL340-R388)

**Robustness and Validation:**

* Implemented a maximum value size check (2048 bytes) for Zabbix usermacros to prevent oversized values from being synced, with appropriate warning logs. (`netbox_zabbix_sync/modules/usermacros.py`) [[1]](diffhunk://#diff-62265bb5c56987395d3a7406715b541e6041c628ff6973564ae06762d7107b71R10-R11) [[2]](diffhunk://#diff-62265bb5c56987395d3a7406715b541e6041c628ff6973564ae06762d7107b71R103-R110)
* Improved type handling in the `field_mapper` utility to support more complex types like lists and dicts, and clarified logging for unexpected types. (`netbox_zabbix_sync/modules/tools.py`) [[1]](diffhunk://#diff-d7d747e735835f1600d0f18be588bc5408a61cd690111f7399156848b4f9fc43L92-R92) [[2]](diffhunk://#diff-d7d747e735835f1600d0f18be588bc5408a61cd690111f7399156848b4f9fc43L105-R105)

**Testing and Maintenance:**

* Refactored test mocks for NetBox devices and VMs to use a more flexible `MockRecord` base class, improving test reliability and code reuse. (`tests/test_core.py`) [[1]](diffhunk://#diff-938de46e643ab091cff6a7c23e4e752e8907e2266f47889d988923352f7a1058L13-R87) [[2]](diffhunk://#diff-938de46e643ab091cff6a7c23e4e752e8907e2266f47889d988923352f7a1058R108) [[3]](diffhunk://#diff-938de46e643ab091cff6a7c23e4e752e8907e2266f47889d988923352f7a1058L111-R186) [[4]](diffhunk://#diff-938de46e643ab091cff6a7c23e4e752e8907e2266f47889d988923352f7a1058R208)
* Removed the test that checked for Zabbix API logout within the main sync loop, as logout is now handled explicitly after sync completion. (`tests/test_core.py`)

**Other Notable Changes:**

* Updated the CLI version string to 4.0.1. (`netbox_zabbix_sync/modules/cli.py`)
* Ensured explicit logout from the Zabbix API after sync completion by adding a `logout()` method and calling it after `start()`. (`netbox_zabbix_sync/modules/core.py`, `netbox_zabbix_sync/modules/cli.py`) [[1]](diffhunk://#diff-ade8b735e1555be949f85a6868a642e45b0b1a02f1d8355dff07741f758e2bfdL120-R183) [[2]](diffhunk://#diff-fe184527e0c6b2d7b25b220a6914f9678aa795f47e2381bfbd68af724b21068bR140)

Let me know if you have questions about any of these changes or need clarification on how they impact the sync process!