### PR TITLE
:sparkles: Add support for OOB IP interface

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -35,11 +35,19 @@ create_hostgroups = True
 ## Create journal entries
 create_journal = False
 
+## Sync Out-Of-Band IPs
+# When set to True, the script will create an additional Zabbix interface for the OOB IP set configured on the device in NetBox.
+# This will need to be a different interface typ than the interface type used for the primary interface.
+# This can be configured through config contxt, see documentation for futher info:
+# https://github.com/TheNetworkGuy/netbox-zabbix-sync/wiki/Sync-Behavior#set-interface-parameters-within-netbox
+oob_sync = False
+
 ## Virtual machine sync
 # Set sync_vms to True in order to use this new feature
 # Use the hostgroup vm_hostgroup_format mapper for specific
 # hostgroup atributes of VM's such as cluster_type and cluster
 sync_vms = False
+
 # Check the README documentation for values to use in the VM hostgroup format.
 vm_hostgroup_format = "cluster_type/cluster/role"
 

--- a/netbox_zabbix_sync/modules/cli.py
+++ b/netbox_zabbix_sync/modules/cli.py
@@ -36,6 +36,7 @@ _BOOL_ARGS = [
         "Fetch additional virtual chassis info from NetBox (increases API queries).",
     ),
     ("inventory_sync", "Sync NetBox device properties to Zabbix inventory."),
+    ("oob_sync", "Sync NetBox Out-of-Band interfaces based on OOB IP."),
     ("usermacro_sync", "Sync usermacros from NetBox to Zabbix."),
     ("tag_sync", "Sync host tags to Zabbix."),
     ("tag_lower", "Lowercase tag names and values before syncing."),

--- a/netbox_zabbix_sync/modules/device.py
+++ b/netbox_zabbix_sync/modules/device.py
@@ -410,6 +410,27 @@ class PhysicalDevice:
         host = self.zabbix.host.get(filter=zbx_filter, output=[])
         return bool(host)
 
+    def _verify_interfaces(self, interfaces: list) -> bool:
+        """
+        Checks if all interfaces are of a unique type
+        """
+        max_interfaces = 2
+        min_interfaces = 1
+        int_types = []
+        if len(interfaces) == min_interfaces:
+            return True
+        elif len(interfaces) > min_interfaces and len(interfaces) <= max_interfaces:
+            int_types = [t.get("type") for t in interfaces]
+            if len(set(int_types)) < len(interfaces):
+                message = "Dublicate interface types found."
+                self.logger.error(message)
+            else:
+                return True
+        else:
+            message = f"Unsupported number of interfaces ({len(interfaces)})."
+            self.logger.error(message)
+        return False
+
     def set_interface_details(self, oob=False):
         """
         Checks interface parameters from NetBox and
@@ -625,6 +646,10 @@ class PhysicalDevice:
             interfaces.append(self.set_interface_details())
             if self.config["oob_sync"] and "oob_ip" in dict(self.nb) and self.nb.oob_ip:
                 interfaces.append(self.set_interface_details(oob=True))
+            if not self._verify_interfaces(interfaces):
+                e = f"Inconsistent interface configuration for host {self.name}."
+                self.logger.error(e)
+                raise SyncInventoryError(e)
             # Set Zabbix proxy if defined
             self._set_proxy(proxies)
             # Set description

--- a/netbox_zabbix_sync/modules/device.py
+++ b/netbox_zabbix_sync/modules/device.py
@@ -1042,8 +1042,6 @@ class PhysicalDevice:
             upd_ints = []
             add_ints = []
             del_ints = False
-            if len(host["interfaces"]) > len(interfaces):
-                del_ints = True
             for interface in interfaces:
                 z_interface = list(
                     filter(
@@ -1059,8 +1057,9 @@ class PhysicalDevice:
                     raise SyncInventoryError(e)
                 else:
                     z_interface = z_interface[0]
-                    # Go through each key / item and check if it matches Zabbix
+                    interface["interfaceid"] = z_interface["interfaceid"]
                     updates = {}
+                    # Go through each key / item and check if it matches Zabbix
                     for key, item in interface.items():
                         # Check if NetBox value is found in Zabbix
                         if key in z_interface:
@@ -1092,6 +1091,11 @@ class PhysicalDevice:
                     if updates:
                         updates["interfaceid"] = z_interface["interfaceid"]
                         upd_ints.append(updates)
+
+            # if we have more interfaces in Zabbix than we expect from netbox,
+            # we'll need to remove some.
+            if len(host["interfaces"]) + len(add_ints) > len(interfaces):
+                del_ints = True
 
             if upd_ints or add_ints or del_ints:
                 # Push changed interface settings
@@ -1129,9 +1133,10 @@ class PhysicalDevice:
                     # If interface updates have been found: push to Zabbix
                     self.logger.info("Host %s: Interface OUT of sync.", self.name)
                     addition["hostid"] = host["hostid"]
+                    response = None
                     try:
                         # API call to Zabbix
-                        self.zabbix.hostinterface.create(addition)
+                        response = self.zabbix.hostinterface.create(addition)
                         err_msg = (
                             f"Host {self.name}: Added interface "
                             f"with data {sanatize_log_output(addition)}."
@@ -1142,16 +1147,46 @@ class PhysicalDevice:
                         msg = f"Zabbix returned the following error: {e}."
                         self.logger.error(msg)
                         raise SyncExternalError(msg) from e
+                    if (
+                        response
+                        and "interfaceids" in response
+                        and len(response["interfaceids"]) == 1
+                    ):
+                        # We need this to not accidentally remove the newly created interface
+                        addition["interfaceid"] = response["interfaceids"][0]
 
                 if del_ints:
-                    self.logger.info("Host %s: Interface OUT of sync.", self.name)
-                    # Removing interfaces is not supported. Raise exception.
-                    e = (
-                        f"Host {self.name}: Need to remove interface(s) and this is not supported. "
-                        f"Manual intervention is required."
-                    )
-                    self.logger.error(e)
-                    raise InterfaceConfigError(e)
+                    # Any interface found in Zabbix but not NetBox will need to be removed.
+                    for interface in host["interfaces"]:
+                        n_interface = []
+                        n_interface = list(
+                            filter(
+                                lambda n_int: n_int["interfaceid"]
+                                == str(interface["interfaceid"]),
+                                interfaces,
+                            )
+                        )
+                        # No matching NetBox interface found, so we remove it.
+                        if not n_interface:
+                            self.logger.info(
+                                "Host %s: Interface OUT of sync.", self.name
+                            )
+                            response = None
+                            try:
+                                # API call to Zabbix
+                                response = self.zabbix.hostinterface.delete(
+                                    interface["interfaceid"]
+                                )
+                                err_msg = (
+                                    f"Host {self.name}: Removed interface "
+                                    f"with data {sanatize_log_output(interface)}."
+                                )
+                                self.logger.info(err_msg)
+                                self.create_journal_entry("info", err_msg)
+                            except APIRequestError as e:
+                                msg = f"Zabbix returned the following error: {e}."
+                                self.logger.error(msg)
+                                raise SyncExternalError(msg) from e
             else:
                 # If no updates are found, Zabbix interface is in-sync
                 self.logger.debug("Host %s: Interface(s) in-sync.", self.name)

--- a/netbox_zabbix_sync/modules/device.py
+++ b/netbox_zabbix_sync/modules/device.py
@@ -67,6 +67,7 @@ class PhysicalDevice:
         self.zabbix_state = 0
         self.journal = journal
         self.nb_journals = nb_journal_class
+        self.oob_ip = None
         self.inventory_mode = -1
         self.inventory = {}
         self.ipmi = {}
@@ -105,6 +106,11 @@ class PhysicalDevice:
             e = f"Host {self.name}: no primary IP."
             self.logger.warning(e)
             raise SyncInventoryError(e)
+
+        # Set OOB IP if available
+        if self.nb.oob_ip:
+            self.oob_cidr = self.nb.oob_ip.address
+            self.oob_ip = self.oob_cidr.split("/")[0]
 
         # Check if device has custom field for ZBX ID
         if self.config["device_cf"] in self.nb.custom_fields:
@@ -404,27 +410,29 @@ class PhysicalDevice:
         host = self.zabbix.host.get(filter=zbx_filter, output=[])
         return bool(host)
 
-    def set_interface_details(self):
+    def set_interface_details(self, oob=False):
         """
         Checks interface parameters from NetBox and
         creates a model for the interface to be used in Zabbix.
         """
+        snmp_interface_type = 2
+        ipmi_interface_type = 3
+        int_ip = self.oob_ip if oob else self.ip
         try:
             # Initiate interface class
-            interface = ZabbixInterface(self.nb.config_context, self.ip)
+            interface = ZabbixInterface(self.nb.config_context, int_ip, oob=oob)
             # Check if NetBox has device context.
             # If not fall back to old config.
             if interface.get_context():
                 # If device is SNMP type, add aditional information.
-                snmp_interface_type = 2
-                ipmi_interface_type = 3
                 if interface.interface["type"] == snmp_interface_type:
                     interface.set_snmp()
+                # Likewise for IPMI
                 elif interface.interface["type"] == ipmi_interface_type:
                     interface.set_ipmi()
             else:
                 interface.set_default_snmp()
-            return [interface.interface]
+            return interface.interface
         except InterfaceConfigError as e:
             message = f"{self.name}: {e}"
             self.logger.warning(message)
@@ -451,12 +459,13 @@ class PhysicalDevice:
             "admin": 4,
             "OEM": 5,
         }
-
+        # See if IPMI is defined in Config Context
         if (
             "zabbix" in self.nb.config_context
             and "ipmi" in self.nb.config_context["zabbix"]
         ):
             ipmi = self.nb.config_context["zabbix"]["ipmi"]
+
             # Check for IPMI user
             if ipmi.get("username"):
                 self.ipmi["username"] = ipmi.get("username")
@@ -597,6 +606,7 @@ class PhysicalDevice:
         """
         Creates Zabbix host object with parameters from NetBox object.
         """
+        interfaces = []
         # Check if hostname is already present in Zabbix
         if not self._zabbix_hostname_exists():
             # Set group and template ID's for host
@@ -611,8 +621,10 @@ class PhysicalDevice:
             templateids = []
             for template in self.zbx_templates:
                 templateids.append({"templateid": template["templateid"]})
-            # Set interface, group and template configuration
-            interfaces = self.set_interface_details()
+            # Setup interfaces
+            interfaces.append(self.set_interface_details())
+            if self.config["oob_sync"] and "oob_ip" in dict(self.nb) and self.nb.oob_ip:
+                interfaces.append(self.set_interface_details(oob=True))
             # Set Zabbix proxy if defined
             self._set_proxy(proxies)
             # Set description

--- a/netbox_zabbix_sync/modules/device.py
+++ b/netbox_zabbix_sync/modules/device.py
@@ -1029,73 +1029,134 @@ class PhysicalDevice:
                 self.logger.info("Host %s: Tags OUT of sync.", self.name)
                 self.update_zabbix_host(tags=self.tags)
 
-        # If only 1 interface has been found
-        if len(host["interfaces"]) == 1:
-            updates = {}
-            # Go through each key / item and check if it matches Zabbix
-            for key, item in self.set_interface_details()[0].items():
-                # Check if NetBox value is found in Zabbix
-                if key in host["interfaces"][0]:
-                    # If SNMP is used, go through nested dict
-                    # to compare SNMP parameters
-                    if isinstance(item, dict) and key == "details":
-                        for k, i in item.items():
-                            # Check if the key is found in Zabbix and if the value matches
-                            if k in host["interfaces"][0][key] and host["interfaces"][
-                                0
-                            ][key][k] != str(i):
-                                # If dict has not been created, add it
-                                if key not in updates:
-                                    updates[key] = {}
-                                updates[key][k] = str(i)
-                                # If SNMP version has been changed
-                                # break loop and force full SNMP update
-                                if k == "version":
-                                    break
-                        # Force full SNMP config update
-                        # when version has changed.
-                        if key in updates and "version" in updates[key]:
-                            for k, i in item.items():
-                                updates[key][k] = str(i)
-                        continue
-                    # Set update if values don't match
-                    if host["interfaces"][0][key] != str(item):
-                        updates[key] = item
-            if updates:
-                # If interface updates have been found: push to Zabbix
-                self.logger.info("Host %s: Interface OUT of sync.", self.name)
-                if "type" in updates:
-                    # Changing interface type not supported. Raise exception.
+        # Verify interfaces
+        interfaces = []
+        interfaces.append(self.set_interface_details())
+        if self.config["oob_sync"] and "oob_ip" in dict(self.nb) and self.nb.oob_ip:
+            interfaces.append(self.set_interface_details(oob=True))
+        if not self._verify_interfaces(interfaces):
+            e = f"Inconsistent interface configuration for host {self.name}."
+            self.logger.error(e)
+            raise SyncInventoryError(e)
+        if interfaces:
+            upd_ints = []
+            add_ints = []
+            del_ints = False
+            if len(host["interfaces"]) > len(interfaces):
+                del_ints = True
+            for interface in interfaces:
+                z_interface = list(
+                    filter(
+                        lambda z_int: z_int["type"] == str(interface["type"]),
+                        host["interfaces"],
+                    )
+                )
+                if not z_interface:
+                    add_ints.append(interface)
+                elif len(z_interface) > 1:
+                    e = f"Multiple interfaces of the same type detecten on host {self.name}, manual intervention required."
+                    self.logger.error(e)
+                    raise SyncInventoryError(e)
+                else:
+                    z_interface = z_interface[0]
+                    # Go through each key / item and check if it matches Zabbix
+                    updates = {}
+                    for key, item in interface.items():
+                        # Check if NetBox value is found in Zabbix
+                        if key in z_interface:
+                            # If SNMP is used, go through nested dict
+                            # to compare SNMP parameters
+                            if isinstance(item, dict) and key == "details":
+                                for k, i in item.items():
+                                    # Check if the key is found in Zabbix and if the value matches
+                                    if k in z_interface[key] and z_interface[key][
+                                        k
+                                    ] != str(i):
+                                        # If dict has not been created, add it
+                                        if key not in updates:
+                                            updates[key] = {}
+                                        updates[key][k] = str(i)
+                                        # If SNMP version has been changed
+                                        # break loop and force full SNMP update
+                                        if k == "version":
+                                            break
+                                # Force full SNMP config update
+                                # when version has changed.
+                                if key in updates and "version" in updates[key]:
+                                    for k, i in item.items():
+                                        updates[key][k] = str(i)
+                                continue
+                            # Set update if values don't match
+                            if z_interface[key] != str(item):
+                                updates[key] = item
+                    if updates:
+                        updates["interfaceid"] = z_interface["interfaceid"]
+                        upd_ints.append(updates)
+
+            if upd_ints or add_ints or del_ints:
+                # Push changed interface settings
+                for updates in upd_ints:
+                    # If interface updates have been found: push to Zabbix
+                    self.logger.info(
+                        "Host %s: Interface %s OUT of sync.",
+                        self.name,
+                        updates["interfaceid"],
+                    )
+                    if "type" in updates:
+                        # Changing interface type not supported. Raise exception.
+                        e = (
+                            f"Host {self.name}: Changing interface type to "
+                            f"{updates['type']} is not supported."
+                        )
+                        self.logger.error(e)
+                        raise InterfaceConfigError(e)
+                    try:
+                        # API call to Zabbix
+                        self.zabbix.hostinterface.update(updates)
+                        err_msg = (
+                            f"Host {self.name}: Updated interface "
+                            f"with data {sanatize_log_output(updates)}."
+                        )
+                        self.logger.info(err_msg)
+                        self.create_journal_entry("info", err_msg)
+                    except APIRequestError as e:
+                        msg = f"Zabbix returned the following error: {e}."
+                        self.logger.error(msg)
+                        raise SyncExternalError(msg) from e
+
+                # Create any new interfaces
+                for addition in add_ints:
+                    # If interface updates have been found: push to Zabbix
+                    self.logger.info("Host %s: Interface OUT of sync.", self.name)
+                    addition["hostid"] = host["hostid"]
+                    try:
+                        # API call to Zabbix
+                        self.zabbix.hostinterface.create(addition)
+                        err_msg = (
+                            f"Host {self.name}: Added interface "
+                            f"with data {sanatize_log_output(addition)}."
+                        )
+                        self.logger.info(err_msg)
+                        self.create_journal_entry("info", err_msg)
+                    except APIRequestError as e:
+                        msg = f"Zabbix returned the following error: {e}."
+                        self.logger.error(msg)
+                        raise SyncExternalError(msg) from e
+
+                if del_ints:
+                    self.logger.info("Host %s: Interface OUT of sync.", self.name)
+                    # Removing interfaces is not supported. Raise exception.
                     e = (
-                        f"Host {self.name}: Changing interface type to "
-                        f"{updates['type']} is not supported."
+                        f"Host {self.name}: Need to remove interface(s) and this is not supported. "
+                        f"Manual intervention is required."
                     )
                     self.logger.error(e)
                     raise InterfaceConfigError(e)
-                # Set interfaceID for Zabbix config
-                updates["interfaceid"] = host["interfaces"][0]["interfaceid"]
-                try:
-                    # API call to Zabbix
-                    self.zabbix.hostinterface.update(updates)
-                    err_msg = (
-                        f"Host {self.name}: Updated interface "
-                        f"with data {sanatize_log_output(updates)}."
-                    )
-                    self.logger.info(err_msg)
-                    self.create_journal_entry("info", err_msg)
-                except APIRequestError as e:
-                    msg = f"Zabbix returned the following error: {e}."
-                    self.logger.error(msg)
-                    raise SyncExternalError(msg) from e
             else:
                 # If no updates are found, Zabbix interface is in-sync
-                self.logger.debug("Host %s: Interface in-sync.", self.name)
+                self.logger.debug("Host %s: Interface(s) in-sync.", self.name)
         else:
-            err_msg = (
-                f"Host {self.name}: Has unsupported interface configuration."
-                f" Host has total of {len(host['interfaces'])} interfaces. "
-                "Manual intervention required."
-            )
+            err_msg = f"Host {self.name}: Has has no interface configuration."
             self.logger.error(err_msg)
             raise SyncInventoryError(err_msg)
 

--- a/netbox_zabbix_sync/modules/device.py
+++ b/netbox_zabbix_sync/modules/device.py
@@ -108,7 +108,7 @@ class PhysicalDevice:
             raise SyncInventoryError(e)
 
         # Set OOB IP if available
-        if self.nb.oob_ip:
+        if "oob_ip" in dict(self.nb) and self.nb.oob_ip:
             self.oob_cidr = self.nb.oob_ip.address
             self.oob_ip = self.oob_cidr.split("/")[0]
 

--- a/netbox_zabbix_sync/modules/device.py
+++ b/netbox_zabbix_sync/modules/device.py
@@ -1117,12 +1117,12 @@ class PhysicalDevice:
                     try:
                         # API call to Zabbix
                         self.zabbix.hostinterface.update(updates)
-                        err_msg = (
+                        log_msg = (
                             f"Host {self.name}: Updated interface "
                             f"with data {sanatize_log_output(updates)}."
                         )
-                        self.logger.info(err_msg)
-                        self.create_journal_entry("info", err_msg)
+                        self.logger.info(log_msg)
+                        self.create_journal_entry("info", log_msg)
                     except APIRequestError as e:
                         msg = f"Zabbix returned the following error: {e}."
                         self.logger.error(msg)
@@ -1137,12 +1137,12 @@ class PhysicalDevice:
                     try:
                         # API call to Zabbix
                         response = self.zabbix.hostinterface.create(addition)
-                        err_msg = (
+                        log_msg = (
                             f"Host {self.name}: Added interface "
                             f"with data {sanatize_log_output(addition)}."
                         )
-                        self.logger.info(err_msg)
-                        self.create_journal_entry("info", err_msg)
+                        self.logger.info(log_msg)
+                        self.create_journal_entry("info", log_msg)
                     except APIRequestError as e:
                         msg = f"Zabbix returned the following error: {e}."
                         self.logger.error(msg)
@@ -1154,6 +1154,10 @@ class PhysicalDevice:
                     ):
                         # We need this to not accidentally remove the newly created interface
                         addition["interfaceid"] = response["interfaceids"][0]
+                    else:
+                        msg = f"Host {self.name}: Unexpected response from Zabbix while adding interface: '{addition['type']}'"
+                        self.logger.error(msg)
+                        raise SyncExternalError(msg)
 
                 if del_ints:
                     # Any interface found in Zabbix but not NetBox will need to be removed.

--- a/netbox_zabbix_sync/modules/device.py
+++ b/netbox_zabbix_sync/modules/device.py
@@ -1184,9 +1184,12 @@ class PhysicalDevice:
                                 self.logger.info(err_msg)
                                 self.create_journal_entry("info", err_msg)
                             except APIRequestError as e:
-                                msg = f"Zabbix returned the following error: {e}."
+                                msg = (
+                                    f"Host {self.name}: Zabbix returned the following error "
+                                    f"while removing an interface: {e} "
+                                    f"Interface: {sanatize_log_output(interface)}."
+                                )
                                 self.logger.error(msg)
-                                raise SyncExternalError(msg) from e
             else:
                 # If no updates are found, Zabbix interface is in-sync
                 self.logger.debug("Host %s: Interface(s) in-sync.", self.name)

--- a/netbox_zabbix_sync/modules/device.py
+++ b/netbox_zabbix_sync/modules/device.py
@@ -422,7 +422,7 @@ class PhysicalDevice:
         elif len(interfaces) > min_interfaces and len(interfaces) <= max_interfaces:
             int_types = [t.get("type") for t in interfaces]
             if len(set(int_types)) < len(interfaces):
-                message = "Dublicate interface types found."
+                message = "Duplicate interface types found."
                 self.logger.error(message)
             else:
                 return True

--- a/netbox_zabbix_sync/modules/interface.py
+++ b/netbox_zabbix_sync/modules/interface.py
@@ -75,13 +75,13 @@ class ZabbixInterface:
                 self.interface["details"] = details
                 # Checks if bulk config has been defined
                 if "bulk" in snmp:
-                    details["bulk"] = str(snmp.pop("bulk"))
+                    details["bulk"] = str(snmp.get("bulk"))
                 else:
                     # Fallback to bulk enabled if not specified
                     details["bulk"] = "1"
                 # SNMP Version config is required in NetBox config context
                 if snmp.get("version"):
-                    details["version"] = str(snmp.pop("version"))
+                    details["version"] = str(snmp.get("version"))
                 else:
                     e = "SNMP version option is not defined."
                     raise InterfaceConfigError(e)

--- a/netbox_zabbix_sync/modules/interface.py
+++ b/netbox_zabbix_sync/modules/interface.py
@@ -38,10 +38,12 @@ class ZabbixInterface:
         if "zabbix" in self.context:
             zabbix = self.context["zabbix"]
             if int_type in zabbix:
+                # Use valid integer for type if set
                 if str(zabbix[int_type]).isdigit() and (
                     int(zabbix[int_type]) > 0 and int(zabbix[int_type]) < max_type
                 ):
                     self.interface["type"] = zabbix[int_type]
+                # Otherwise, convert string to type integer
                 elif zabbix[int_type].lower() in int_types:
                     self.interface["type"] = int_types[zabbix[int_type].lower()]
                 else:

--- a/netbox_zabbix_sync/modules/interface.py
+++ b/netbox_zabbix_sync/modules/interface.py
@@ -8,8 +8,9 @@ from netbox_zabbix_sync.modules.exceptions import InterfaceConfigError
 class ZabbixInterface:
     """Class that represents a Zabbix interface."""
 
-    def __init__(self, context, ip):
+    def __init__(self, context, ip, oob=False):
         self.context = context
+        self.is_oob = oob
         self.ip = ip
         self.skelet = {"main": "1", "useip": "1", "dns": "", "ip": self.ip}
         self.interface = self.skelet
@@ -26,15 +27,40 @@ class ZabbixInterface:
 
     def get_context(self):
         """check if NetBox custom context has been defined."""
+        int_types = {"agent": 1, "snmp": 2, "ipmi": 3, "jmx": 4}
+        int_type = "interface_type"
+        int_port = "interface_port"
+        max_port = 65536
+        max_type = 5
+        if self.is_oob:
+            int_type = "oob_interface_type"
+            int_port = "oob_interface_port"
         if "zabbix" in self.context:
             zabbix = self.context["zabbix"]
-            if "interface_type" in zabbix:
-                self.interface["type"] = zabbix["interface_type"]
-                if "interface_port" not in zabbix:
+            if int_type in zabbix:
+                if str(zabbix[int_type]).isdigit() and (
+                    int(zabbix[int_type]) > 0 and int(zabbix[int_type]) < max_type
+                ):
+                    self.interface["type"] = zabbix[int_type]
+                elif zabbix[int_type].lower() in int_types:
+                    self.interface["type"] = int_types[zabbix[int_type].lower()]
+                else:
+                    e = f"Interface type '{zabbix[int_type]}' is not valid."
+                    raise InterfaceConfigError(e)
+                # Use default port if not specified in Config Context
+                if int_port not in zabbix:
                     self._set_default_port()
                     return True
-                self.interface["port"] = zabbix["interface_port"]
-                return True
+                # Otherwise, validate Config Context port value
+                elif str(zabbix[int_port]).isdigit() and (
+                    int(zabbix[int_port]) > 0 and int(zabbix[int_port]) < max_port
+                ):
+                    self.interface["port"] = zabbix[int_port]
+                    return True
+                else:
+                    e = f"Interface port '{zabbix[int_port]}' is not valid."
+                    raise InterfaceConfigError(e)
+                return False
             return False
         return False
 

--- a/netbox_zabbix_sync/modules/settings.py
+++ b/netbox_zabbix_sync/modules/settings.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 logger = getLogger(__name__)
 
-# PLEASE NOTE: This is a sample config file. Please do NOT make any edits in this file!
+# PLEASE NOTE: This is a defaults config file. Please do NOT make any edits in this file!
 # You should create your own config.py and it will overwrite the default config.
 
 DEFAULT_CONFIG = {
@@ -20,6 +20,7 @@ DEFAULT_CONFIG = {
     "proxy_cf": False,
     "proxy_group_cf": False,
     "clustering": False,
+    "oob_sync": False,
     "create_hostgroups": True,
     "create_journal": False,
     "sync_vms": False,

--- a/netbox_zabbix_sync/modules/tools.py
+++ b/netbox_zabbix_sync/modules/tools.py
@@ -242,20 +242,23 @@ def sanatize_log_output(data):
             sanitized_data["ipmi_password"] = "********"  # noqa: S105
     # Check for interface data
     if "interfaceid" in data:
-        # Interface ID is a value which is most likely not helpful
-        # in logging output or for troubleshooting.
-        del sanitized_data["interfaceid"]
-        # InterfaceID also hints that this is a interface update.
+        # InterfaceID hints that this is a interface update.
         # A check is required if there are no macro's used for SNMP security parameters.
-        if "details" not in data:
+        if data.get("details"):
+            for key, detail in sanitized_data["details"].items():
+                # If the detail is a secret, we don't want to log it.
+                if key in (
+                    "authpassphrase",
+                    "privpassphrase",
+                    "securityname",
+                    "community",
+                ):
+                    # Check if a macro is used.
+                    # If so then logging the output is not a security issue.
+                    if detail.startswith("{$") and detail.endswith("}"):
+                        continue
+                    # A macro is not used, so we sanitize the value.
+                    sanitized_data["details"][key] = "********"
+        else:
             return sanitized_data
-        for key, detail in sanitized_data["details"].items():
-            # If the detail is a secret, we don't want to log it.
-            if key in ("authpassphrase", "privpassphrase", "securityname", "community"):
-                # Check if a macro is used.
-                # If so then logging the output is not a security issue.
-                if detail.startswith("{$") and detail.endswith("}"):
-                    continue
-                # A macro is not used, so we sanitize the value.
-                sanitized_data["details"][key] = "********"
     return sanitized_data

--- a/netbox_zabbix_sync/modules/virtual_machine.py
+++ b/netbox_zabbix_sync/modules/virtual_machine.py
@@ -57,7 +57,7 @@ class VirtualMachine(PhysicalDevice):
                     interface.set_snmp()
             else:
                 interface.set_default_agent()
-            return [interface.interface]
+            return interface.interface
         except InterfaceConfigError as e:
             message = f"{self.name}: {e}"
             self.logger.warning(message)

--- a/netbox_zabbix_sync/modules/virtual_machine.py
+++ b/netbox_zabbix_sync/modules/virtual_machine.py
@@ -40,7 +40,7 @@ class VirtualMachine(PhysicalDevice):
             self.logger.warning(e)
         return True
 
-    def set_interface_details(self):
+    def set_interface_details(self,oob=False):
         """
         Overwrites device function to select an agent interface type by default
         Agent type interfaces are more likely to be used with VMs then SNMP

--- a/netbox_zabbix_sync/modules/virtual_machine.py
+++ b/netbox_zabbix_sync/modules/virtual_machine.py
@@ -40,7 +40,7 @@ class VirtualMachine(PhysicalDevice):
             self.logger.warning(e)
         return True
 
-    def set_interface_details(self,oob=False):
+    def set_interface_details(self, oob=False):
         """
         Overwrites device function to select an agent interface type by default
         Agent type interfaces are more likely to be used with VMs then SNMP

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1064,6 +1064,7 @@ class TestDeviceStatusHandling(unittest.TestCase):
         mock_zabbix.proxygroup.get.return_value = []
         mock_zabbix.host.get.return_value = []
         mock_zabbix.host.create.return_value = {"hostids": ["1"]}
+        mock_zabbix.hostinterface.create.return_value = {"interfaceids": ["92"]}
         mock_zabbix.host.update.return_value = {"hostids": ["42"]}
         mock_zabbix.host.delete.return_value = [42]
         return mock_zabbix
@@ -1081,7 +1082,7 @@ class TestDeviceStatusHandling(unittest.TestCase):
                 "status": status,
                 # Single empty-dict interface: len==1 avoids SyncInventoryError,
                 # empty keys prevent any spurious interface-update calls.
-                "interfaces": [{"type": "1", "port": "10050"}],
+                "interfaces": [{"type": "1", "port": "10050", "interfaceid": "69"}],
                 "inventory_mode": "-1",
                 "inventory": {},
                 "macros": [],
@@ -1385,7 +1386,7 @@ class TestVMStatusHandling(unittest.TestCase):
                 "status": status,
                 # Single empty-dict interface: len==1 avoids SyncInventoryError,
                 # empty keys mean no spurious interface-update calls.
-                "interfaces": [{"type": "1", "port": "10050"}],
+                "interfaces": [{"type": "1", "port": "10050", "interfaceid": "123"}],
                 "inventory_mode": "-1",
                 "inventory": {},
                 "macros": [],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1081,7 +1081,7 @@ class TestDeviceStatusHandling(unittest.TestCase):
                 "status": status,
                 # Single empty-dict interface: len==1 avoids SyncInventoryError,
                 # empty keys prevent any spurious interface-update calls.
-                "interfaces": [{}],
+                "interfaces": [{"type": "1", "port": "10050"}],
                 "inventory_mode": "-1",
                 "inventory": {},
                 "macros": [],
@@ -1385,7 +1385,7 @@ class TestVMStatusHandling(unittest.TestCase):
                 "status": status,
                 # Single empty-dict interface: len==1 avoids SyncInventoryError,
                 # empty keys mean no spurious interface-update calls.
-                "interfaces": [{}],
+                "interfaces": [{"type": "1", "port": "10050"}],
                 "inventory_mode": "-1",
                 "inventory": {},
                 "macros": [],

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -32,8 +32,6 @@ def test_sanatize_log_output_interface_secrets():
     # Non-sensitive fields should remain
     assert sanitized["details"]["community"] == "********"
     assert sanitized["details"]["other"] == "normalvalue"
-    # interfaceid should be removed
-    assert "interfaceid" not in sanitized
 
 
 def test_sanatize_log_output_interface_macros():
@@ -52,7 +50,6 @@ def test_sanatize_log_output_interface_macros():
     assert sanitized["details"]["privpassphrase"] == "{$SECRET_MACRO}"
     assert sanitized["details"]["securityname"] == "{$USER_MACRO}"
     assert sanitized["details"]["community"] == "{$SNNMP_COMMUNITY}"
-    assert "interfaceid" not in sanitized
 
 
 def test_sanatize_log_output_plain_data():


### PR DESCRIPTION
This PR adds functionality to manage an additional OOB interface from NetBox, see also #40.

- allow the use of `oob_sync` in config and cli to enable the syncing of OOB interface to Zabbix.
- enable setting OOB interface parameters from config context
- implemented new interface consistency check to account for multiple interfaces

Primary and OOB interfaces will need to be different types, for example:

- primary: agent, oob: snmp
- primary: agent, oob: ipmi
- primary: snmp, oob: ipmi

Having interfaces of the same type is not supported and will result in an error during sync!
