### PR TITLE
✨ Added preferred_ip setting instead of using netbox_device.primary_ip

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -29,6 +29,13 @@ clustering = False
 # Be aware that this will increase the number of API queries to NetBox.
 extended_virtual_chassis = False
 
+## Preferred IP version
+# This setting determines which IP address will be used for the Zabbix host interface when a device has multiple IP addresses assigned.
+# The following options are available:
+# ipv4: Use the IPv4 address (default)
+# ipv6: Use the IPv6 address
+preferred_ip = "ipv4"
+
 ## Enable hostgroup generation. Requires permissions in Zabbix
 create_hostgroups = True
 

--- a/config.py.example
+++ b/config.py.example
@@ -32,9 +32,10 @@ extended_virtual_chassis = False
 ## Preferred IP version
 # This setting determines which IP address will be used for the Zabbix host interface when a device has multiple IP addresses assigned.
 # The following options are available:
-# ipv4: Use the IPv4 address (default)
-# ipv6: Use the IPv6 address
-preferred_ip = "ipv4"
+# auto: Use primary_ip field by NetBox. (default)
+# ipv4: Prefer IPv4 address over IPv6 address.
+# ipv6: Prefer IPv6 address over IPv4 address.
+preferred_ip = "auto"
 
 ## Enable hostgroup generation. Requires permissions in Zabbix
 create_hostgroups = True

--- a/netbox_zabbix_sync/modules/cli.py
+++ b/netbox_zabbix_sync/modules/cli.py
@@ -67,6 +67,11 @@ _STR_ARGS = [
         "NetBox tag property to use as the Zabbix tag value (name, slug, or display).",
         "PROPERTY",
     ),
+    (
+        "preferred_ip",
+        "Preferred IP version for inventory sync (ipv4 (default) or ipv6).",
+        "IP_VERSION",
+    ),
 ]
 
 

--- a/netbox_zabbix_sync/modules/device.py
+++ b/netbox_zabbix_sync/modules/device.py
@@ -98,9 +98,17 @@ class PhysicalDevice:
         """
         Sets basic information like IP address.
         """
+
+        primary = None
+
         # Return error if device does not have primary IP.
-        if self.nb.primary_ip:
-            self.cidr = self.nb.primary_ip.address
+        if self.config["preferred_ip"] == "ipv6":
+            primary = self.nb.primary_ip6 or self.nb.primary_ip4
+        else:
+            primary = self.nb.primary_ip4 or self.nb.primary_ip6
+
+        if primary:
+            self.cidr = primary.address
             self.ip = self.cidr.split("/")[0]
         else:
             e = f"Host {self.name}: no primary IP."

--- a/netbox_zabbix_sync/modules/device.py
+++ b/netbox_zabbix_sync/modules/device.py
@@ -101,8 +101,10 @@ class PhysicalDevice:
 
         primary = None
 
-        # Return error if device does not have primary IP.
-        if self.config["preferred_ip"] == "ipv6":
+        # Determine which IP address to use based on config setting. Default is to use the primary IP as set in NetBox, but can be overruled to prefer IPv4 or IPv6 addresses.
+        if self.config["preferred_ip"] == "auto":
+            primary = self.nb.primary_ip
+        elif self.config["preferred_ip"] == "ipv6":
             primary = self.nb.primary_ip6 or self.nb.primary_ip4
         else:
             primary = self.nb.primary_ip4 or self.nb.primary_ip6

--- a/netbox_zabbix_sync/modules/settings.py
+++ b/netbox_zabbix_sync/modules/settings.py
@@ -37,7 +37,7 @@ DEFAULT_CONFIG = {
     "inventory_sync": False,
     "extended_site_properties": False,
     "extended_virtual_chassis": False,
-    "preferred_ip": "ipv4",
+    "preferred_ip": "auto",
     "device_inventory_map": {
         "asset_tag": "asset_tag",
         "virtual_chassis/name": "chassis",

--- a/netbox_zabbix_sync/modules/settings.py
+++ b/netbox_zabbix_sync/modules/settings.py
@@ -37,6 +37,7 @@ DEFAULT_CONFIG = {
     "inventory_sync": False,
     "extended_site_properties": False,
     "extended_virtual_chassis": False,
+    "preferred_ip": "ipv4",
     "device_inventory_map": {
         "asset_tag": "asset_tag",
         "virtual_chassis/name": "chassis",

--- a/tests/test_device_deletion.py
+++ b/tests/test_device_deletion.py
@@ -48,7 +48,7 @@ class TestDeviceDeletion(unittest.TestCase):
             "3.0",
             journal=True,
             logger=self.mock_logger,
-            config={"device_cf": "zabbix_hostid"},
+            config={"device_cf": "zabbix_hostid", "preferred_ip": "auto"},
         )
 
     def test_cleanup_successful_deletion(self):
@@ -154,7 +154,7 @@ class TestDeviceDeletion(unittest.TestCase):
             "3.0",
             journal=False,  # Disable journaling
             logger=self.mock_logger,
-            config={"device_cf": "zabbix_hostid"},
+            config={"device_cf": "zabbix_hostid", "preferred_ip": "auto"},
         )
 
         # Execute

--- a/tests/test_physical_device.py
+++ b/tests/test_physical_device.py
@@ -53,6 +53,7 @@ class TestPhysicalDevice(unittest.TestCase):
                 "inventory_mode": "disabled",
                 "inventory_sync": False,
                 "device_inventory_map": {},
+                "preferred_ip": "auto",
             },
         )
 
@@ -82,7 +83,7 @@ class TestPhysicalDevice(unittest.TestCase):
                 self.mock_nb_journal,
                 "3.0",
                 logger=self.mock_logger,
-                config={"device_cf": "zabbix_hostid"},
+                config={"device_cf": "zabbix_hostid", "preferred_ip": "auto"},
             )
 
         # With the mocked search function, the name should be changed to NETBOX_ID format
@@ -106,7 +107,7 @@ class TestPhysicalDevice(unittest.TestCase):
             self.mock_nb_journal,
             "3.0",
             logger=self.mock_logger,
-            config={"device_cf": "zabbix_hostid"},
+            config={"device_cf": "zabbix_hostid", "preferred_ip": "auto"},
         )
 
         # Test that templates are returned correctly
@@ -125,7 +126,7 @@ class TestPhysicalDevice(unittest.TestCase):
             self.mock_nb_journal,
             "3.0",
             logger=self.mock_logger,
-            config={"device_cf": "zabbix_hostid"},
+            config={"device_cf": "zabbix_hostid", "preferred_ip": "auto"},
         )
 
         # Test that template is wrapped in a list
@@ -144,7 +145,7 @@ class TestPhysicalDevice(unittest.TestCase):
             self.mock_nb_journal,
             "3.0",
             logger=self.mock_logger,
-            config={"device_cf": "zabbix_hostid"},
+            config={"device_cf": "zabbix_hostid", "preferred_ip": "auto"},
         )
 
         # Test that TemplateError is raised
@@ -163,7 +164,7 @@ class TestPhysicalDevice(unittest.TestCase):
             self.mock_nb_journal,
             "3.0",
             logger=self.mock_logger,
-            config={"device_cf": "zabbix_hostid"},
+            config={"device_cf": "zabbix_hostid", "preferred_ip": "auto"},
         )
 
         # Test that TemplateError is raised
@@ -185,7 +186,7 @@ class TestPhysicalDevice(unittest.TestCase):
                 self.mock_nb_journal,
                 "3.0",
                 logger=self.mock_logger,
-                config={"device_cf": "zabbix_hostid"},
+                config={"device_cf": "zabbix_hostid", "preferred_ip": "auto"},
             )
 
             # Call set_template with prefer_config_context=True
@@ -202,6 +203,7 @@ class TestPhysicalDevice(unittest.TestCase):
         # Configure with disabled inventory mode
         config_patch = {
             "device_cf": "zabbix_hostid",
+            "preferred_ip": "auto",
             "inventory_mode": "disabled",
             "inventory_sync": False,
         }
@@ -228,6 +230,7 @@ class TestPhysicalDevice(unittest.TestCase):
             "device_cf": "zabbix_hostid",
             "inventory_mode": "manual",
             "inventory_sync": False,
+            "preferred_ip": "auto",
         }
 
         device = PhysicalDevice(
@@ -251,6 +254,7 @@ class TestPhysicalDevice(unittest.TestCase):
             "device_cf": "zabbix_hostid",
             "inventory_mode": "automatic",
             "inventory_sync": False,
+            "preferred_ip": "auto",
         }
 
         device = PhysicalDevice(
@@ -275,6 +279,7 @@ class TestPhysicalDevice(unittest.TestCase):
             "inventory_mode": "manual",
             "inventory_sync": True,
             "device_inventory_map": {"name": "name", "serial": "serialno_a"},
+            "preferred_ip": "auto",
         }
 
         device = PhysicalDevice(
@@ -309,7 +314,7 @@ class TestPhysicalDevice(unittest.TestCase):
             self.mock_nb_journal,
             "3.0",
             logger=self.mock_logger,
-            config={"device_cf": "zabbix_hostid"},
+            config={"device_cf": "zabbix_hostid", "preferred_ip": "auto"},
         )
 
         # Check isCluster result
@@ -327,7 +332,7 @@ class TestPhysicalDevice(unittest.TestCase):
             self.mock_nb_journal,
             "3.0",
             logger=self.mock_logger,
-            config={"device_cf": "zabbix_hostid"},
+            config={"device_cf": "zabbix_hostid", "preferred_ip": "auto"},
         )
 
         # Check isCluster result

--- a/tests/test_usermacros.py
+++ b/tests/test_usermacros.py
@@ -34,7 +34,11 @@ class TestUsermacroSync(unittest.TestCase):
         mock_nb.primary_ip.address = "192.168.1.1/24"
         mock_nb.custom_fields = {"zabbix_hostid": None}
 
-        device_config = config if config is not None else {"device_cf": "zabbix_hostid"}
+        device_config = (
+            config
+            if config is not None
+            else {"device_cf": "zabbix_hostid", "preferred_ip": "auto"}
+        )
 
         # Create device with proper initialization
         device = PhysicalDevice(
@@ -56,6 +60,7 @@ class TestUsermacroSync(unittest.TestCase):
                 "usermacro_sync": False,
                 "device_cf": "zabbix_hostid",
                 "tag_sync": False,
+                "preferred_ip": "auto",
             }
         )
 
@@ -82,6 +87,7 @@ class TestUsermacroSync(unittest.TestCase):
                 "usermacro_sync": True,
                 "device_cf": "zabbix_hostid",
                 "tag_sync": False,
+                "preferred_ip": "auto",
             }
         )
 
@@ -108,6 +114,7 @@ class TestUsermacroSync(unittest.TestCase):
                 "usermacro_sync": "full",
                 "device_cf": "zabbix_hostid",
                 "tag_sync": False,
+                "preferred_ip": "auto",
             }
         )
 


### PR DESCRIPTION
The `primary_ip` property on a NetBox devices prefers IPv6 when set. This is not always desired, so this PR adds an option for the user to select a IP version. For backwards compatibility, default behavior is to use the `primary_ip` object with lets NetBox decide the primary IP.

The user is free to add a `preferred_ip` configuration to the config, allowing for the values `auto`, `ipv4` or `ipv6`.