### PR TITLE
:bug: Fix template and interface order during update

### DIFF
--- a/netbox_zabbix_sync/modules/host.py
+++ b/netbox_zabbix_sync/modules/host.py
@@ -899,20 +899,6 @@ class Host(ABC):
                 )
                 self.update_zabbix_host(name=self.visible_name)
 
-        # Check if the templates are in-sync
-        if not self.zbx_template_comparer(host["parentTemplates"]):
-            self.logger.info("Host %s: Template(s) OUT of sync.", self.name)
-            # Prepare Templates for API parsing
-            templateids = []
-            for template in self.zbx_templates:
-                templateids.append({"templateid": template["templateid"]})
-            # Update Zabbix with NB templates and clear any old / lost templates
-            self.update_zabbix_host(
-                templates_clear=host["parentTemplates"], templates=templateids
-            )
-        else:
-            self.logger.debug("Host %s: Template(s) in-sync.", self.name)
-
         group_dictname = "hostgroups"
         # Check if Zabbix version is 6 or higher. Issue #93
         if str(self.zabbix.version).startswith(("6", "5")):
@@ -1254,6 +1240,20 @@ class Host(ABC):
             err_msg = f"Host {self.name}: Has has no interface configuration."
             self.logger.error(err_msg)
             raise SyncInventoryError(err_msg)
+
+        # Check if the templates are in-sync, needs to be donw after interfaces.
+        if not self.zbx_template_comparer(host["parentTemplates"]):
+            self.logger.info("Host %s: Template(s) OUT of sync.", self.name)
+            # Prepare Templates for API parsing
+            templateids = []
+            for template in self.zbx_templates:
+                templateids.append({"templateid": template["templateid"]})
+            # Update Zabbix with NB templates and clear any old / lost templates
+            self.update_zabbix_host(
+                templates_clear=host["parentTemplates"], templates=templateids
+            )
+        else:
+            self.logger.debug("Host %s: Template(s) in-sync.", self.name)
 
     def create_journal_entry(self, severity, message):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,12 +8,26 @@ idna==3.11
     # via requests
 igraph==1.0.0
     # via netbox-zabbix-sync
+j2ipaddr==1.0.6
+    # via netbox-zabbix-sync
+jinja2==3.1.6
+    # via netbox-zabbix-sync
+markupsafe==3.0.3
+    # via jinja2
+netaddr==1.3.0
+    # via j2ipaddr
 packaging==26.0
     # via pynetbox
 pynetbox==7.6.1
     # via netbox-zabbix-sync
+python-dateutil==2.9.0.post0
+    # via netbox-zabbix-sync
+python-jsonpath==2.0.2
+    # via netbox-zabbix-sync
 requests==2.32.5
     # via pynetbox
+six==1.17.0
+    # via python-dateutil
 texttable==1.7.0
     # via igraph
 urllib3==2.6.3


### PR DESCRIPTION
We currently assign templates before creating interfaces during a new config run.
If the newly added template needs a specific type of interface, adding the template fails because the interface is not there yet.

This PR changes the order of operations to make this work as intended.