### PR TITLE
✨ Added skip_version_check for runs against unsupported Zabbix versions

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -198,3 +198,8 @@ vm_tag_map = {"site/name": "site",
 # This will allow you to perform advanced NetBox lookups and transform data before passing it to Zabbix.
 # See https://github.com/TheNetworkGuy/netbox-zabbix-sync/wiki/Experimental-Features#config-context-rendering
 render_config_context = False
+
+## Skip version Check
+# Disabled zabbix_utils version check, allows for runs against unsupported Zabbix versions (ex: development and release candidates)
+# DOES NOT GUARANTEE CORRECT FUNCTION OF THE SYNC SCRIPT! This feature is only to be used for development and testing!
+skip_version_check = False

--- a/netbox_zabbix_sync/modules/cli.py
+++ b/netbox_zabbix_sync/modules/cli.py
@@ -153,6 +153,7 @@ def main(arguments):
         zbx_user=zabbix_user,
         zbx_pass=zabbix_pass,
         zbx_token=zabbix_token,
+        skip_version_check=config["skip_version_check"],
     )
     if config["render_config_context"]:
         logger.warning(

--- a/netbox_zabbix_sync/modules/core.py
+++ b/netbox_zabbix_sync/modules/core.py
@@ -106,18 +106,25 @@ class Sync:
         return True
 
     def connect(
-        self, nb_host, nb_token, zbx_host, zbx_user=None, zbx_pass=None, zbx_token=None
+        self,
+        nb_host,
+        nb_token,
+        zbx_host,
+        zbx_user=None,
+        zbx_pass=None,
+        zbx_token=None,
+        skip_version_check=False,
     ):
         """
-        Docstring for connect
+        Connect to NetBox and Zabbix APIs using provided credentials and settings.
 
-        :param self: Description
-        :param nb_host: Description
-        :param nb_token: Description
-        :param zbx_host: Description
-        :param zbx_user: Description
-        :param zbx_pass: Description
-        :param zbx_token: Description
+        :param nb_host: NetBox host URL
+        :param nb_token: NetBox API token
+        :param zbx_host: Zabbix host URL
+        :param zbx_user: Zabbix username
+        :param zbx_pass: Zabbix password
+        :param zbx_token: Zabbix API token
+        :param skip_version_check: Whether to skip version checking
         """
         # Initialize Netbox API connection
         netbox = nbapi(nb_host, token=nb_token, threading=True)
@@ -160,11 +167,20 @@ class Sync:
             if not zbx_token:
                 logger.debug("Using user/password authentication for Zabbix API.")
                 self.zabbix = ZabbixAPI(
-                    zbx_host, user=zbx_user, password=zbx_pass, ssl_context=ssl_ctx
+                    zbx_host,
+                    user=zbx_user,
+                    password=zbx_pass,
+                    ssl_context=ssl_ctx,
+                    skip_version_check=skip_version_check,
                 )
             else:
                 logger.debug("Using token authentication for Zabbix API.")
-                self.zabbix = ZabbixAPI(zbx_host, token=zbx_token, ssl_context=ssl_ctx)
+                self.zabbix = ZabbixAPI(
+                    zbx_host,
+                    token=zbx_token,
+                    ssl_context=ssl_ctx,
+                    skip_version_check=skip_version_check,
+                )
             self.zabbix.check_auth()
             logger.debug("Zabbix version is %s.", self.zabbix.version)
         except (APIRequestError, ProcessingError) as zbx_error:

--- a/netbox_zabbix_sync/modules/settings.py
+++ b/netbox_zabbix_sync/modules/settings.py
@@ -90,6 +90,7 @@ DEFAULT_CONFIG = {
     "description_dt_format": "%Y-%m-%d %H:%M:%S",
     "description": "static",
     "render_config_context": False,
+    "skip_version_check": False,
 }
 
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -212,7 +212,7 @@ def nb(netbox_url, netbox_token):
 @pytest.fixture(scope="session")
 def zapi(zabbix_url, zabbix_credentials):
     user, password = zabbix_credentials
-    api = ZabbixAPI(zabbix_url, user=user, password=password)
+    api = ZabbixAPI(zabbix_url, user=user, password=password, skip_version_check=True)
     yield api
     api.logout()
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -30,6 +30,7 @@ BASE_CONFIG = {
     "create_hostgroups": True,
     "hostgroup_format": "site/manufacturer/role",
     "create_journal": False,
+    "skip_version_check": True,  # Running tests against version matrix, allow for experimental versions
 }
 
 
@@ -285,6 +286,7 @@ def sync_runner(
             zbx_host=zabbix_url,
             zbx_user=user,
             zbx_pass=password,
+            skip_version_check=BASE_CONFIG["skip_version_check"],
         ), "Sync.connect() failed; it returns False rather than raising"
         # Everything up to here -- fixture setup, seeding, connect()'s auth
         # probe -- is noise to `netbox_requests`, whose contract is the traffic


### PR DESCRIPTION
This pull request introduces a new configuration option to skip the Zabbix version check, which is useful for development and testing against unsupported or experimental Zabbix versions. The option is integrated throughout the configuration, core connection logic, and test suite.

Configuration changes:

* Added a new `skip_version_check` option to `config.py.example`, `settings.py`, and test configuration files, allowing users to bypass the Zabbix version check. [[1]](diffhunk://#diff-d81370c2aa8ae22f210cdf48c95702f98326a198e9ddad046fc02ddd5e65159aR201-R205) [[2]](diffhunk://#diff-97e9516cf589a2d6488c85de1d781390896bf190b38e224cf7b5094a743b73b9R93) [[3]](diffhunk://#diff-9810a028f51682f62bc400e8654365eca614e1905cc524507818b9a22329dca8R33)

Core logic updates:

* Updated the `connect` method in the core module to accept and pass through the `skip_version_check` parameter to the `ZabbixAPI` initialization, ensuring the version check can be conditionally disabled. [[1]](diffhunk://#diff-ade8b735e1555be949f85a6868a642e45b0b1a02f1d8355dff07741f758e2bfdL109-R127) [[2]](diffhunk://#diff-ade8b735e1555be949f85a6868a642e45b0b1a02f1d8355dff07741f758e2bfdL163-R183)
* Modified the CLI module to pass the `skip_version_check` configuration value when establishing connections.

Testing improvements:

* Updated the functional test configuration and test connection setup to enable `skip_version_check`, supporting tests against a version matrix including experimental Zabbix versions. [[1]](diffhunk://#diff-9810a028f51682f62bc400e8654365eca614e1905cc524507818b9a22329dca8R33) [[2]](diffhunk://#diff-9810a028f51682f62bc400e8654365eca614e1905cc524507818b9a22329dca8R289)