### PR TITLE
✅ Add tests for host attributes and improve coverage for features

### DIFF
--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -110,6 +110,13 @@ The site also carries latitude/longitude, which `extended_site_properties` is
 the only way to reach. Per-test devices come from the `device_factory` fixture
 and per-test VMs from `vm_factory`.
 
+Both factories allocate a unique IP by default, out of `10.128/9`, which is kept
+clear of every hard-coded address in the suite. Pass `address=` only when the
+test asserts on the value; NetBox rejects a duplicate address globally, so a
+shared default would make any two-device test fail for a reason unrelated to what
+it is testing. Both factories also register their object for cleanup *before*
+creating its interface and IP, so a failure part-way through still tears down.
+
 The seeded template is `Linux by SNMP`, and that pairing is deliberate: a device
 with no `zabbix` config context gets an **SNMP** interface (`host.py:496` calls
 `set_default_snmp()`; only VMs default to agent), and Zabbix refuses to link an
@@ -224,12 +231,68 @@ templates come **only** from its config context (there is no custom-field
 fallback), so a VM with no `zabbix` context is dropped before Zabbix sees it —
 which is why `vm_factory` gives every VM one by default.
 
+## Testing the settings one by one
+
+Four files exist to cover the settings in `DEFAULT_CONFIG` that nothing else
+reaches. They share a rule, which is the one worth internalising before adding
+to them:
+
+> **A setting is only tested if changing it changes the assertion.** A test that
+> sets `zabbix_device_disable` to a status the default list already contains
+> passes whether or not the setting was ever read. So each test either drives a
+> value the defaults put somewhere else, or is paired with an off-state test
+> using identical NetBox data.
+
+- **`test_status_and_journal.py`** — `zabbix_device_removal` and
+  `zabbix_device_disable` (both driven with statuses the defaults classify
+  differently), `create_hostgroups`, and `create_journal`, the one setting whose
+  effect lands in NetBox rather than Zabbix. Note the config lists are written in
+  status **labels** (`"Offline"`), not slugs — `Host.status` is `nb.status.label`.
+- **`test_interfaces.py`** — `preferred_ip` and `oob_sync`. Every `preferred_ip`
+  test uses a dual-stack device, because that is the only thing that tells the
+  three values apart; `"auto"` defers to NetBox, which resolves `primary_ip` to
+  v6 when both exist. `oob_sync` has a sharp edge worth knowing: both interfaces
+  fall back to SNMP, `_verify_interfaces` rejects duplicate types, so enabling
+  the flag without an `oob_interface_type` in config context drops every device
+  that has an OOB IP.
+- **`test_proxies.py`** — `proxy_cf`, `proxy_group_cf` and `full_proxy_sync`,
+  against proxies that really exist in Zabbix, since the whole feature is a
+  name lookup. Covers the three-level precedence (device custom field, then the
+  same field on the site, then config context) with each level set to a
+  *different* proxy so the order is observable. `full_proxy_sync` is the only
+  setting in the suite that deletes Zabbix configuration, so both its states are
+  pinned.
+- **`test_templates.py`** — `template_cf`. Every test uses a custom field whose
+  name the default would never find, because the seed data uses the default name
+  and a sync ignoring the setting would otherwise pass.
+
+Two teardown-ordering traps show up here and are worth copying rather than
+rediscovering. Zabbix refuses to delete a hostgroup that still holds a host, or a
+proxy a host still points at — so `zabbix_hostgroups` and `proxy_factory` are
+requested **before** `device_factory` in a test signature. Finalizers run in
+reverse setup order, so first in the signature means last at teardown. And any
+test that writes a custom field onto a session-seeded object (the site, the
+device type) refetches it first: the shared `Record` keeps whatever
+`custom_fields` it last saved, including ones a fixture has since deleted, and
+sending those back is a 400.
+
+Two bugs found here are filed as ISSUES.md 5 and 6 and pinned as xfails (see
+below). A third finding is pinned as a **passing** test instead: **turning
+`oob_sync` off does not remove the interface** from a host that already synced,
+because Zabbix refuses to delete an interface with template items bound to it.
+The sync logs the rejection and carries on, so the setting is effectively
+one-way. That is pinned as-is rather than xfailed deliberately — forcing the
+removal would mean unlinking Zabbix items the sync did not create, so an xfail
+would encode a fix nobody should make (ISSUES.md issue 7).
+
 ## The xfail markers
 
-Five tests are marked `xfail(strict=True)`. They are not flaky, and they are not
+Seven tests are marked `xfail(strict=True)`. They are not flaky, and they are not
 aspirational: each is a bug these tests found, asserting the behaviour that
 should hold, with the reason on the marker. Strict means they fail the moment
-the behaviour is fixed, which is the signal to drop the marker.
+the behaviour is fixed, which is the signal to drop the marker. Each corresponds
+to a numbered entry in `ISSUES.md`, where the trade-offs a fix has to weigh are
+written up.
 
 - `field_mapper` raises `KeyError` on a mapped field NetBox did not nest, rather
   than mapping it to `""` like an empty value. It escapes `Sync.start()`, which
@@ -249,6 +312,16 @@ the behaviour is fixed, which is the signal to drop the marker.
   a hostgroup with the whole region path missing
   (`test_ambiguous_region_name_still_traverses`, and at unit level
   `tests/test_tools.py::TestBuildPath::test_reused_ancestor_name_still_resolves`).
+- The **host description is never reconciled**. `Description.generate()` is
+  called only from `create_in_zabbix`, so `description` and
+  `description_dt_format` silently do nothing on any host Zabbix already has
+  (`test_a_changed_description_reaches_an_existing_host`). The test uses a
+  macro-free description on purpose, so it does not prejudge how a fix should
+  handle `{datetime}` — see ISSUES.md issue 5.
+- A **meaningless `description_dt_format` reaches Zabbix verbatim**. `strftime`
+  passes unknown directives like `%Q` through rather than raising, so the
+  `except ValueError` guard is unreachable and only a non-string format falls
+  back (`test_a_meaningless_dt_format_falls_back_to_the_default`).
 
 One non-obvious finding is pinned as a passing test rather than an xfail:
 `extended_site_properties` is a no-op for devices. `Hostgroup` reads

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -105,7 +105,8 @@ mocked suite would report itself.
 `seed_netbox.py` creates the shared objects: the `zabbix_hostid` and
 `zabbix_template` custom fields, plus the site, manufacturer, device type and
 role that the default `hostgroup_format` of `site/manufacturer/role` requires.
-Per-test devices come from the `device_factory` fixture.
+The site also carries latitude/longitude, which `extended_site_properties` is
+the only way to reach. Per-test devices come from the `device_factory` fixture.
 
 The seeded template is `Linux by SNMP`, and that pairing is deliberate: a device
 with no `zabbix` config context gets an **SNMP** interface (`host.py:496` calls
@@ -154,4 +155,55 @@ endpoint.
 
 Custom fields are global in NetBox, so a leftover one would quietly change what
 these tests prove; `custom_field_factory` gives each test unique names and
-deletes them afterwards.
+deletes them afterwards. `tag_factory` exists for the same reason.
+
+## Testing the generated host attributes
+
+`test_host_attributes.py` (tags, usermacros, inventory), `test_config_context.py`
+(interface/template config, Jinja2 rendering) and `test_extended_models.py` (the
+`extended_*` settings) cover the mapping features. The mocked suite already
+covers how those structures are *built*; these cover the two ends a mock cannot:
+
+- **Zabbix accepts them.** An inventory key that is not one of Zabbix's ~70
+  inventory fields is an API error, not a stored value. A mocked test asserting
+  on the dict handed to a mock passes with a typo'd field name in the map.
+- **NetBox serves what the map asks for.** A map names fields by path
+  (`site/latitude`); whether that path exists on the object NetBox actually
+  returns is not something a `DummyNB` can answer.
+
+Devices get their config context from `local_context_data`, the device-local
+layer NetBox merges into the rendered `config_context`. It needs no
+ConfigContext object or assignment rules, and it cannot leak into another
+test's device the way a site- or role-scoped context would.
+
+The rule from the filter tests has a counterpart here: **a feature switch that
+is only tested in its on state is not tested.** Asserting tags appear with
+`tag_sync=True` proves nothing unless something also proves they stay away when
+it is off — so each switch is paired with its off state.
+
+## The xfail markers
+
+Four tests are marked `xfail(strict=True)`. They are not flaky, and they are not
+aspirational: each is a bug these tests found, asserting the behaviour that
+should hold, with the reason on the marker. Strict means they fail the moment
+the behaviour is fixed, which is the signal to drop the marker.
+
+- `field_mapper` raises `KeyError` on a mapped field NetBox did not nest, rather
+  than mapping it to `""` like an empty value. It escapes `Sync.start()`, which
+  catches `SyncError` only, so one such field ends the whole run
+  (`test_unextended_mapped_field_aborts_the_run`, and at unit level
+  `tests/test_tools.py::TestFieldMapper::test_absent_field_maps_to_empty_string`).
+- `render_config_context=True` skips every host whose config context has no
+  usable `zabbix` key — which is most of an inventory — because
+  `jinjafy_config_context` returns `{}` for those and `core.py:211` reads a
+  falsy render as a failure (`test_rendering_skips_hosts_with_no_zabbix_context`,
+  three parametrised cases).
+
+One non-obvious finding is pinned as a passing test rather than an xfail:
+`extended_site_properties` is a no-op for devices. `Hostgroup` reads
+`self.nb.site.region` for every device with a site, and a nested pynetbox
+`Record` lazily fetches its full details on *attribute* access, so the site is
+fully populated either way — same data, same request count with the flag on and
+off (`test_site_costs_one_fetch_per_host_either_way`). That also explains why
+`field_mapper` misses fields that are "there": it walks with `Record[key]`,
+which is `dict(self)[key]` and does not lazy-load.

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -104,9 +104,11 @@ mocked suite would report itself.
 
 `seed_netbox.py` creates the shared objects: the `zabbix_hostid` and
 `zabbix_template` custom fields, plus the site, manufacturer, device type and
-role that the default `hostgroup_format` of `site/manufacturer/role` requires.
+role that the default `hostgroup_format` of `site/manufacturer/role` requires,
+and a cluster and cluster type for the VM tests' `cluster_type/cluster/role`.
 The site also carries latitude/longitude, which `extended_site_properties` is
-the only way to reach. Per-test devices come from the `device_factory` fixture.
+the only way to reach. Per-test devices come from the `device_factory` fixture
+and per-test VMs from `vm_factory`.
 
 The seeded template is `Linux by SNMP`, and that pairing is deliberate: a device
 with no `zabbix` config context gets an **SNMP** interface (`host.py:496` calls
@@ -181,9 +183,50 @@ is only tested in its on state is not tested.** Asserting tags appear with
 `tag_sync=True` proves nothing unless something also proves they stay away when
 it is off — so each switch is paired with its off state.
 
+`test_host_attributes.py` also covers what a *bad* map does, which is where the
+two ends part company. A key Zabbix rejects — a typo'd inventory field, a macro
+or tag value past Zabbix's length limit — fails only its own host: Zabbix
+refuses the `host.create`, the sync catches it and moves on. A NetBox path that
+does not resolve does the opposite and ends the whole run (see the xfail
+markers). The client-side length checks in `usermacros.py` and `tags.py` are
+load-bearing for the same reason — dropping an oversized value before the call
+is what keeps one verbose NetBox `comments` field from failing the host.
+
+## Testing the shipped default maps
+
+Every other mapping test names its own map, which exercises the mechanism and
+says nothing about the ~20 mappings in `DEFAULT_CONFIG` that users get out of
+the box. `test_default_maps.py` covers those specifically: it passes **no** map,
+lets the defaults apply, and asserts on what Zabbix stored. It is the only test
+that fails when a shipped default drifts from either end — a Zabbix inventory
+field that no longer exists, or a NetBox path (`device_type/manufacturer/name`)
+that a NetBox release stops nesting. It asserts every entry rather than a
+sample, because a spot check leaves the rest free to rot, and it runs against
+both a fully-populated device (every path resolves) and a bare one (every
+nullable path maps to `""` rather than raising).
+
+## Testing hostgroups and VMs
+
+`test_hostgroups.py` covers the most visible mapping of all — where each host
+lands in Zabbix. Beyond the default `site/manufacturer/role`, it exercises the
+things only a real NetBox tree can show: nested regions and site groups walked
+by `build_path` (which reconstructs ancestry from `_depth`/`parent`), a quoted
+literal segment, a custom-field segment, and an empty segment dropping out. Each
+`traverse_*` flag is paired with its off state.
+
+`test_vm_sync.py` is the VM counterpart to the device tests. A VM is not a
+device with a different endpoint: it takes a different branch in `start()`, a
+different class, and four different config keys (`vm_inventory_map`,
+`vm_usermacro_map`, `vm_tag_map`, `vm_hostgroup_format`), none of which a device
+test reaches. Two divergences are the kind only a real Zabbix enforces: a VM
+defaults to an **agent** interface where a device defaults to SNMP, and a VM's
+templates come **only** from its config context (there is no custom-field
+fallback), so a VM with no `zabbix` context is dropped before Zabbix sees it —
+which is why `vm_factory` gives every VM one by default.
+
 ## The xfail markers
 
-Four tests are marked `xfail(strict=True)`. They are not flaky, and they are not
+Five tests are marked `xfail(strict=True)`. They are not flaky, and they are not
 aspirational: each is a bug these tests found, asserting the behaviour that
 should hold, with the reason on the marker. Strict means they fail the moment
 the behaviour is fixed, which is the signal to drop the marker.
@@ -193,11 +236,19 @@ the behaviour is fixed, which is the signal to drop the marker.
   catches `SyncError` only, so one such field ends the whole run
   (`test_unextended_mapped_field_aborts_the_run`, and at unit level
   `tests/test_tools.py::TestFieldMapper::test_absent_field_maps_to_empty_string`).
+  Contrast `test_unknown_inventory_field_costs_only_its_own_host`, which pins the
+  Zabbix-side version of the same user error: it fails one host, not the run.
 - `render_config_context=True` skips every host whose config context has no
   usable `zabbix` key — which is most of an inventory — because
   `jinjafy_config_context` returns `{}` for those and `core.py:211` reads a
   falsy render as a failure (`test_rendering_skips_hosts_with_no_zabbix_context`,
   three parametrised cases).
+- `build_path` matches ancestors by **name**, but NetBox only enforces unique
+  region names at the top level. A region name reused under two parents makes the
+  ancestry ambiguous, `build_path` returns `[]`, and the device silently lands in
+  a hostgroup with the whole region path missing
+  (`test_ambiguous_region_name_still_traverses`, and at unit level
+  `tests/test_tools.py::TestBuildPath::test_reused_ancestor_name_still_resolves`).
 
 One non-obvious finding is pinned as a passing test rather than an xfail:
 `extended_site_properties` is a no-op for devices. `Hostgroup` reads

--- a/tests/functional/bootstrap/seed_netbox.py
+++ b/tests/functional/bootstrap/seed_netbox.py
@@ -29,6 +29,14 @@ ZABBIX_TEMPLATE = "Linux by SNMP"
 # above and hostgroup_format "site/manufacturer/role".
 EXPECTED_HOSTGROUP = f"{SITE_NAME}/{MANUFACTURER_NAME}/{ROLE_NAME}"
 
+# Geo data on the site. NetBox does not include these in the *nested* site it
+# returns on a device, so they are only reachable once `extended_site_properties`
+# has called full_details() -- which is exactly what the extended_site_properties
+# tests use them to prove. Stored as strings because that is how NetBox returns
+# these decimal fields, and field_mapper str()s whatever it finds.
+SITE_LATITUDE = "52.370216"
+SITE_LONGITUDE = "4.895168"
+
 
 def _get_or_create(endpoint, search: dict, create: dict):
     """Return the existing object matching `search`, else create it."""
@@ -71,8 +79,21 @@ def seed(nb) -> dict:
     site = _get_or_create(
         nb.dcim.sites,
         {"slug": SITE_SLUG},
-        {"name": SITE_NAME, "slug": SITE_SLUG, "status": "active"},
+        {
+            "name": SITE_NAME,
+            "slug": SITE_SLUG,
+            "status": "active",
+            "latitude": SITE_LATITUDE,
+            "longitude": SITE_LONGITUDE,
+        },
     )
+    # An earlier run may have created the site without geo data, so set it
+    # unconditionally rather than only on create -- same reasoning as the
+    # device type's template custom field below.
+    if str(site.latitude) != SITE_LATITUDE or str(site.longitude) != SITE_LONGITUDE:
+        site.latitude = SITE_LATITUDE
+        site.longitude = SITE_LONGITUDE
+        site.save()
     manufacturer = _get_or_create(
         nb.dcim.manufacturers,
         {"slug": MANUFACTURER_SLUG},

--- a/tests/functional/bootstrap/seed_netbox.py
+++ b/tests/functional/bootstrap/seed_netbox.py
@@ -25,9 +25,25 @@ ROLE_SLUG = "server"
 # has no agent interface.
 ZABBIX_TEMPLATE = "Linux by SNMP"
 
+# The mirror image of the above, and for the mirrored reason: a VM gets an
+# AGENT interface by default (virtual_machine.py:set_interface_details, "agent
+# type interfaces are more likely to be used with VMs"), so linking the SNMP
+# template to a VM is the same error in the other direction.
+ZABBIX_VM_TEMPLATE = "Linux by Zabbix agent"
+
+# The default vm_hostgroup_format is "cluster_type/cluster/role", so a VM needs
+# a cluster -- which carries the type -- and a role, the way a device needs a
+# site, manufacturer and role.
+CLUSTER_TYPE_NAME = "Proxmox"
+CLUSTER_TYPE_SLUG = "proxmox"
+CLUSTER_NAME = "cluster-01"
+
 # The hostgroup the sync should build for a seeded device, given the defaults
 # above and hostgroup_format "site/manufacturer/role".
 EXPECTED_HOSTGROUP = f"{SITE_NAME}/{MANUFACTURER_NAME}/{ROLE_NAME}"
+
+# The same for a seeded VM, given vm_hostgroup_format "cluster_type/cluster/role".
+EXPECTED_VM_HOSTGROUP = f"{CLUSTER_TYPE_NAME}/{CLUSTER_NAME}/{ROLE_NAME}"
 
 # Geo data on the site. NetBox does not include these in the *nested* site it
 # returns on a device, so they are only reachable once `extended_site_properties`
@@ -120,10 +136,24 @@ def seed(nb) -> dict:
         {"slug": ROLE_SLUG},
         {"name": ROLE_NAME, "slug": ROLE_SLUG, "color": "00bcd4"},
     )
+    # The same role serves devices and VMs: NetBox 4 dropped the separate
+    # device_role model, so `role` on both points at dcim.device_roles.
+    cluster_type = _get_or_create(
+        nb.virtualization.cluster_types,
+        {"slug": CLUSTER_TYPE_SLUG},
+        {"name": CLUSTER_TYPE_NAME, "slug": CLUSTER_TYPE_SLUG},
+    )
+    cluster = _get_or_create(
+        nb.virtualization.clusters,
+        {"name": CLUSTER_NAME},
+        {"name": CLUSTER_NAME, "type": cluster_type.id, "status": "active"},
+    )
 
     return {
         "site": site,
         "manufacturer": manufacturer,
         "device_type": device_type,
         "role": role,
+        "cluster_type": cluster_type,
+        "cluster": cluster,
     }

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -32,6 +32,11 @@ BASE_CONFIG = {
     "create_journal": False,
 }
 
+# Distinguishes "the caller said None" from "the caller said nothing", where
+# None is a meaningful value rather than an absence -- vm_factory's config
+# context being the case that needs it.
+UNSET = object()
+
 
 FUNCTIONAL_DIR = Path(__file__).parent
 
@@ -243,6 +248,7 @@ def device_factory(nb, zapi, seeded):
         tags: list[int] | None = None,
         dns_name: str = "",
         oob_address: str | None = None,
+        site: int | None = None,
         **fields,
     ):
         name = f"fn-{uuid4().hex[:8]}"
@@ -250,7 +256,11 @@ def device_factory(nb, zapi, seeded):
             name=name,
             device_type=seeded["device_type"].id,
             role=seeded["role"].id,
-            site=seeded["site"].id,
+            # Named rather than left to **fields: the seeded site is the default
+            # and would collide with a site= passed through as a plain field.
+            # Overridden by the hostgroup tests, which need a site carrying a
+            # region or a site group.
+            site=site or seeded["site"].id,
             status=status,
             local_context_data=config_context,
             tags=tags or [],
@@ -297,6 +307,82 @@ def device_factory(nb, zapi, seeded):
         # while the device still names that IP as its primary or OOB.
         for obj in (*dependents[1:], device):
             # Already gone, or removed by a cascading delete.
+            with contextlib.suppress(pynetbox.RequestError):
+                obj.delete()
+
+
+def vm_context(**zabbix_keys) -> dict:
+    """A VM config context carrying the agent template, plus whatever is added.
+
+    Every VM that is expected to sync needs one. A VM takes its templates from
+    the config context alone -- `set_vm_template` deliberately skips the custom
+    field lookup devices use (virtual_machine.py:35) -- and core.py:371 drops a
+    VM with no templates before it ever reaches Zabbix. So a VM test that sets a
+    config context for some other purpose has to carry the template along, or it
+    silently stops testing what it meant to.
+    """
+    return {"zabbix": {"templates": [seed_netbox.ZABBIX_VM_TEMPLATE], **zabbix_keys}}
+
+
+@pytest.fixture
+def vm_factory(nb, zapi, seeded):
+    """Create uniquely-named NetBox VMs and clean up after the test.
+
+    The device_factory's counterpart. Two differences are worth knowing:
+    `config_context` defaults to `vm_context()` rather than nothing, because a
+    VM without one never reaches Zabbix at all (see `vm_context`); and the VM
+    gets `site` as well as `cluster`, since the default vm_tag_map maps
+    `site/name` and a site is optional for VMs.
+    """
+    created = []
+
+    def make(
+        status: str = "active",
+        address: str = "10.1.0.1/24",
+        config_context=UNSET,
+        tags: list[int] | None = None,
+        dns_name: str = "",
+        **fields,
+    ):
+        name = f"fn-vm-{uuid4().hex[:8]}"
+        vm = nb.virtualization.virtual_machines.create(
+            name=name,
+            cluster=seeded["cluster"].id,
+            role=seeded["role"].id,
+            site=seeded["site"].id,
+            status=status,
+            local_context_data=vm_context()
+            if config_context is UNSET
+            else config_context,
+            tags=tags or [],
+            **fields,
+        )
+        dependents = [vm]
+        interface = nb.virtualization.interfaces.create(
+            virtual_machine=vm.id, name="eth0"
+        )
+        ip = nb.ipam.ip_addresses.create(
+            address=address,
+            dns_name=dns_name,
+            assigned_object_type="virtualization.vminterface",
+            assigned_object_id=interface.id,
+        )
+        dependents += [ip, interface]
+        vm.primary_ip4 = ip.id
+        vm.save()
+        vm = nb.virtualization.virtual_machines.get(vm.id)
+        created.append((vm, dependents))
+        return vm
+
+    yield make
+
+    for vm, dependents in reversed(created):
+        for host in zapi.host.get(filter={"host": vm.name}, output=["hostid"]):
+            zapi.host.delete(host["hostid"])
+        # The VM goes last, for the same reason the device does: NetBox refuses
+        # to delete the interface an IP hangs off while the VM still names that
+        # IP as its primary.
+        for obj in (*dependents[1:], vm):
             with contextlib.suppress(pynetbox.RequestError):
                 obj.delete()
 
@@ -402,6 +488,31 @@ def run_sync(sync_runner):
 
     def _run(device_name: str, **overrides):
         sync_runner(device_filter={"name": device_name}, **overrides)
+
+    return _run
+
+
+# A device name no device has, used to scope a VM sync down to its VM. The
+# devices half of start() runs regardless of sync_vms, so without this a VM test
+# also syncs whatever devices another test left in NetBox.
+NO_DEVICES = {"name": "fn-no-such-device"}
+
+
+@pytest.fixture
+def run_vm_sync(sync_runner):
+    """Run the real Sync, scoped to one VM, with sync_vms on.
+
+    `sync_vms` defaults to False, so a VM test that forgets it passes an empty
+    NetBox for the VM half and asserts nothing. It is set here rather than left
+    to each test, and can still be overridden to test the off state.
+    """
+
+    def _run(vm_name: str, **overrides):
+        sync_runner(
+            device_filter=NO_DEVICES,
+            vm_filter={"name": vm_name},
+            **{"sync_vms": True, **overrides},
+        )
 
     return _run
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -8,6 +8,7 @@ nothing may connect to anything at import time.
 import contextlib
 import os
 from ipaddress import ip_interface
+from itertools import count
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 from uuid import uuid4
@@ -36,6 +37,18 @@ BASE_CONFIG = {
 # None is a meaningful value rather than an absence -- vm_factory's config
 # context being the case that needs it.
 UNSET = object()
+
+# NetBox rejects a duplicate address in the global table, so every device and VM
+# needs its own even when the test does not care what it is. 10.128/9 is left
+# free by the tests that do hard-code an address (all of them in 10.0, 10.1,
+# 10.20 or 192.168), so a generated address can never collide with a named one.
+_address_counter = count()
+
+
+def next_address() -> str:
+    """An address no other host in the run is using."""
+    n = next(_address_counter)
+    return f"10.128.{n // 254}.{n % 254 + 1}/24"
 
 
 FUNCTIONAL_DIR = Path(__file__).parent
@@ -243,11 +256,12 @@ def device_factory(nb, zapi, seeded):
 
     def make(
         status: str = "active",
-        address: str = "10.0.0.1/24",
+        address: str | None = None,
         config_context: dict | None = None,
         tags: list[int] | None = None,
         dns_name: str = "",
         oob_address: str | None = None,
+        address6: str | None = None,
         site: int | None = None,
         **fields,
     ):
@@ -269,6 +283,11 @@ def device_factory(nb, zapi, seeded):
         # Deleted in list order, so anything that must go before the device it
         # points at is appended after it.
         dependents = [device]
+        # Registered before the dependents exist so a failure below still tears
+        # the device down. `dependents` is mutated in place from here on, so the
+        # tuple already in `created` keeps seeing the additions.
+        created.append((device, dependents))
+        address = address or next_address()
         interface = nb.dcim.interfaces.create(
             device=device.id, name="eth0", type="1000base-t"
         )
@@ -280,6 +299,18 @@ def device_factory(nb, zapi, seeded):
         )
         dependents += [ip, interface]
         device.primary_ip4 = ip.id
+
+        if address6:
+            # Hung off the same interface as the v4 address, which is how a
+            # dual-stack host is normally modelled and keeps `preferred_ip`
+            # the only thing choosing between the two.
+            ip6 = nb.ipam.ip_addresses.create(
+                address=address6,
+                assigned_object_type="dcim.interface",
+                assigned_object_id=interface.id,
+            )
+            dependents.insert(1, ip6)
+            device.primary_ip6 = ip6.id
 
         if oob_address:
             oob_interface = nb.dcim.interfaces.create(
@@ -294,9 +325,10 @@ def device_factory(nb, zapi, seeded):
             device.oob_ip = oob_ip.id
 
         device.save()
-        device = nb.dcim.devices.get(device.id)
-        created.append((device, dependents))
-        return device
+        # Refetched so the caller sees the primary IP it just assigned. The
+        # copy registered for cleanup above stays as it is -- teardown only
+        # needs the id and the name, and both are already on it.
+        return nb.dcim.devices.get(device.id)
 
     yield make
 
@@ -338,7 +370,7 @@ def vm_factory(nb, zapi, seeded):
 
     def make(
         status: str = "active",
-        address: str = "10.1.0.1/24",
+        address: str | None = None,
         config_context=UNSET,
         tags: list[int] | None = None,
         dns_name: str = "",
@@ -358,11 +390,14 @@ def vm_factory(nb, zapi, seeded):
             **fields,
         )
         dependents = [vm]
+        # Registered before its dependents, so a failure below still cleans up.
+        # See the same note in device_factory.
+        created.append((vm, dependents))
         interface = nb.virtualization.interfaces.create(
             virtual_machine=vm.id, name="eth0"
         )
         ip = nb.ipam.ip_addresses.create(
-            address=address,
+            address=address or next_address(),
             dns_name=dns_name,
             assigned_object_type="virtualization.vminterface",
             assigned_object_id=interface.id,
@@ -370,9 +405,7 @@ def vm_factory(nb, zapi, seeded):
         dependents += [ip, interface]
         vm.primary_ip4 = ip.id
         vm.save()
-        vm = nb.virtualization.virtual_machines.get(vm.id)
-        created.append((vm, dependents))
-        return vm
+        return nb.virtualization.virtual_machines.get(vm.id)
 
     yield make
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -227,10 +227,24 @@ def device_factory(nb, zapi, seeded):
 
     Cleanup covers Zabbix too: a synced device leaves a host behind, and the
     next test would otherwise see it.
+
+    The optional arguments exist for the attribute-generation features. Config
+    context arrives as `local_context_data`, the device-local layer NetBox
+    merges into the rendered `config_context` the sync reads: it needs no
+    ConfigContext object, no assignment rules, and it cannot leak into another
+    test's device the way a site- or role-scoped context would.
     """
     created = []
 
-    def make(status: str = "active", address: str = "10.0.0.1/24"):
+    def make(
+        status: str = "active",
+        address: str = "10.0.0.1/24",
+        config_context: dict | None = None,
+        tags: list[int] | None = None,
+        dns_name: str = "",
+        oob_address: str | None = None,
+        **fields,
+    ):
         name = f"fn-{uuid4().hex[:8]}"
         device = nb.dcim.devices.create(
             name=name,
@@ -238,30 +252,112 @@ def device_factory(nb, zapi, seeded):
             role=seeded["role"].id,
             site=seeded["site"].id,
             status=status,
+            local_context_data=config_context,
+            tags=tags or [],
+            **fields,
         )
+        # Deleted in list order, so anything that must go before the device it
+        # points at is appended after it.
+        dependents = [device]
         interface = nb.dcim.interfaces.create(
             device=device.id, name="eth0", type="1000base-t"
         )
         ip = nb.ipam.ip_addresses.create(
             address=address,
+            dns_name=dns_name,
             assigned_object_type="dcim.interface",
             assigned_object_id=interface.id,
         )
+        dependents += [ip, interface]
         device.primary_ip4 = ip.id
+
+        if oob_address:
+            oob_interface = nb.dcim.interfaces.create(
+                device=device.id, name="mgmt0", type="1000base-t"
+            )
+            oob_ip = nb.ipam.ip_addresses.create(
+                address=oob_address,
+                assigned_object_type="dcim.interface",
+                assigned_object_id=oob_interface.id,
+            )
+            dependents += [oob_ip, oob_interface]
+            device.oob_ip = oob_ip.id
+
         device.save()
         device = nb.dcim.devices.get(device.id)
-        created.append((device, interface, ip))
+        created.append((device, dependents))
         return device
 
     yield make
 
-    for device, interface, ip in reversed(created):
+    for device, dependents in reversed(created):
         for host in zapi.host.get(filter={"host": device.name}, output=["hostid"]):
             zapi.host.delete(host["hostid"])
-        for obj in (ip, interface, device):
+        # The device goes last: NetBox refuses to delete an IP's interface
+        # while the device still names that IP as its primary or OOB.
+        for obj in (*dependents[1:], device):
             # Already gone, or removed by a cascading delete.
             with contextlib.suppress(pynetbox.RequestError):
                 obj.delete()
+
+
+@pytest.fixture
+def tag_factory(nb):
+    """Create uniquely-named NetBox tags and remove them afterwards.
+
+    Tags are global, like custom fields, so each test gets its own rather than
+    risking a leftover tag turning up in another test's Zabbix host tags.
+    """
+    created = []
+
+    def make(name: str | None = None):
+        slug = f"tag-{uuid4().hex[:8]}"
+        tag = nb.extras.tags.create(name=name or slug.upper(), slug=slug)
+        created.append(tag)
+        return tag
+
+    yield make
+
+    for tag in reversed(created):
+        with contextlib.suppress(pynetbox.RequestError):
+            tag.delete()
+
+
+@pytest.fixture
+def virtual_chassis_factory(nb, zapi):
+    """Create a virtual chassis over existing devices, master first.
+
+    Torn down before `device_factory`'s devices: this fixture is requested
+    after it, so its finalizer runs first, and NetBox nulls the members'
+    `virtual_chassis` on delete rather than blocking on it.
+
+    Cleanup deletes the Zabbix host named after the chassis as well. With
+    `clustering` on, the master is promoted to the chassis name (device.py:57),
+    so the host it leaves behind is not named after any device and
+    `device_factory` would never find it.
+    """
+    created = []
+
+    def make(master, *members, domain: str = ""):
+        # domain is nullable in NetBox's model but not over the API, which
+        # rejects an explicit null with a 400.
+        vc = nb.dcim.virtual_chassis.create(
+            name=f"vc-{uuid4().hex[:8]}", master=master.id, domain=domain
+        )
+        for position, device in enumerate((master, *members), start=1):
+            device.virtual_chassis = vc.id
+            device.vc_position = position
+            device.save()
+        created.append(vc)
+        return vc
+
+    yield make
+
+    for vc in reversed(created):
+        for host in zapi.host.get(filter={"host": vc.name}, output=["hostid"]):
+            zapi.host.delete(host["hostid"])
+        with contextlib.suppress(pynetbox.RequestError):
+            vc.delete()
 
 
 @pytest.fixture
@@ -406,7 +502,13 @@ def custom_field_factory(nb):
 
 @pytest.fixture
 def zabbix_host(zapi):
-    """Read a Zabbix host back with everything the assertions need."""
+    """Read a Zabbix host back with everything the assertions need.
+
+    Tags, macros and inventory are selected here rather than in a second
+    fixture because Zabbix omits each of them unless asked, and a test that
+    forgot the select would read an absent key as an absent value -- passing
+    for a host whose tags were never synced.
+    """
 
     def _get(name: str):
         hosts = zapi.host.get(
@@ -415,10 +517,33 @@ def zabbix_host(zapi):
             selectHostGroups=["name"],
             selectParentTemplates=["host"],
             selectInterfaces="extend",
+            selectTags="extend",
+            selectMacros="extend",
+            selectInventory="extend",
         )
         return hosts[0] if hosts else None
 
     return _get
+
+
+def tag_pairs(host: dict) -> set[tuple[str, str]]:
+    """The host's Zabbix tags as (tag, value) pairs."""
+    return {(tag["tag"], tag["value"]) for tag in host["tags"]}
+
+
+def macro_values(host: dict) -> dict[str, str | None]:
+    """The host's Zabbix usermacros, keyed by macro name.
+
+    A secret macro's value is `None`: Zabbix withholds it by dropping the key
+    from the response entirely, rather than blanking it. Read `macro_types` to
+    assert on one.
+    """
+    return {macro["macro"]: macro.get("value") for macro in host["macros"]}
+
+
+def macro_types(host: dict) -> dict[str, str]:
+    """The host's usermacro types (0 text, 1 secret, 2 vault), by macro name."""
+    return {macro["macro"]: macro["type"] for macro in host["macros"]}
 
 
 def strip_ip_mask(address: str) -> str:

--- a/tests/functional/test_config_context.py
+++ b/tests/functional/test_config_context.py
@@ -1,0 +1,391 @@
+"""Config context: what it configures, and rendering it through Jinja2.
+
+Config context is the main customisation surface -- it sets the interface type,
+the templates, the macros and the tags for one device without touching the
+config file. Two things here are worth a live stack:
+
+- **The config context the sync reads is NetBox's, not the test's.** These
+  tests set `local_context_data` and assert on the result, so what they
+  exercise is the context NetBox rendered and served. A mock is handed the
+  final dict and skips the step that can actually be wrong.
+- **Jinja renders against real NetBox data.** `jinjafy_config_context` templates
+  the zabbix key with `data` bound to the device dict (tools.py:67). Whether
+  `data.serial` resolves depends on how NetBox serialises a device, which is
+  precisely what a DummyNB cannot tell you.
+
+The rendering tests pair each assertion with its unrendered state: a test that
+only asserts `{{ data.serial }}` becomes the serial would also pass if Jinja
+ran unconditionally, which would be a bug -- render_config_context is
+experimental and off by default.
+"""
+
+import pytest
+
+from tests.functional.bootstrap.seed_netbox import ZABBIX_TEMPLATE
+from tests.functional.conftest import macro_values, tag_pairs
+
+AGENT_INTERFACE_TYPE = "1"
+SNMP_INTERFACE_TYPE = "2"
+
+# A second template from the Zabbix default dataset. SNMP, like ZABBIX_TEMPLATE:
+# Zabbix refuses to link an agent template to a host with no agent interface,
+# and a device with no config context gets an SNMP interface (host.py:496).
+SECOND_TEMPLATE = "Generic by SNMP"
+
+
+# --- config context as host configuration -----------------------------------
+
+
+def test_interface_type_and_port_from_config_context(
+    device_factory, run_sync, zabbix_host
+):
+    """Config context turns the default SNMP interface into an agent one.
+
+    Also the reason the seeded template is SNMP: this is the one device in the
+    suite that legitimately has an agent interface, so it takes an agent
+    template to match (interface.py:38-68).
+    """
+    device = device_factory(
+        address="10.0.0.80/24",
+        config_context={
+            "zabbix": {
+                "interface_type": "agent",
+                "interface_port": "10055",
+                "templates": ["Zabbix agent"],
+            }
+        },
+    )
+
+    run_sync(device.name, templates_config_context=True)
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    assert len(host["interfaces"]) == 1
+    interface = host["interfaces"][0]
+    assert interface["type"] == AGENT_INTERFACE_TYPE
+    assert interface["port"] == "10055", "config context port was ignored"
+
+
+def test_snmp_details_from_config_context(device_factory, run_sync, zabbix_host):
+    """SNMP v2 community and bulk settings reach the Zabbix interface details.
+
+    `details` is a nested structure Zabbix validates per SNMP version, so a
+    wrong shape is rejected at host.create rather than quietly stored.
+    """
+    device = device_factory(
+        address="10.0.0.81/24",
+        config_context={
+            "zabbix": {
+                "interface_type": "snmp",
+                "snmp": {"community": "{$SNMP_COMMUNITY}", "version": 2, "bulk": 0},
+            }
+        },
+    )
+
+    run_sync(device.name)
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    interface = host["interfaces"][0]
+    assert interface["type"] == SNMP_INTERFACE_TYPE
+    details = interface["details"]
+    assert details["version"] == "2"
+    assert details["bulk"] == "0"
+    assert details["community"] == "{$SNMP_COMMUNITY}"
+
+
+def test_templates_from_config_context(device_factory, run_sync, zabbix_host):
+    """templates_config_context=True takes templates from the context.
+
+    The device type's custom field still says `Linux by SNMP`, so a sync that
+    ignored the flag would link that instead -- the assertion excludes it
+    rather than only looking for the context's template.
+    """
+    device = device_factory(
+        address="10.0.0.82/24",
+        config_context={"zabbix": {"templates": [SECOND_TEMPLATE]}},
+    )
+
+    run_sync(device.name, templates_config_context=True)
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    templates = {template["host"] for template in host["parentTemplates"]}
+    assert templates == {SECOND_TEMPLATE}
+    assert ZABBIX_TEMPLATE not in templates, "custom field template was used anyway"
+
+
+def test_config_context_overrules_custom_field_template(
+    device_factory, run_sync, zabbix_host
+):
+    """With overrule set, a context template beats the custom field's."""
+    device = device_factory(
+        address="10.0.0.83/24",
+        config_context={"zabbix": {"templates": [SECOND_TEMPLATE]}},
+    )
+
+    run_sync(device.name, templates_config_context_overrule=True)
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    templates = {template["host"] for template in host["parentTemplates"]}
+    assert templates == {SECOND_TEMPLATE}
+
+
+def test_overrule_falls_back_to_custom_field(device_factory, run_sync, zabbix_host):
+    """Overrule with no context templates falls back to the custom field.
+
+    The other half of the flag (host.py:261-268): overruling must not mean
+    "context or nothing", or every device without a context would stop syncing.
+    """
+    device = device_factory(address="10.0.0.84/24")
+
+    run_sync(device.name, templates_config_context_overrule=True)
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    templates = {template["host"] for template in host["parentTemplates"]}
+    assert templates == {ZABBIX_TEMPLATE}
+
+
+# --- Jinja2 rendering (experimental) ----------------------------------------
+
+
+def test_config_context_not_rendered_by_default(device_factory, run_sync, zabbix_host):
+    """Without render_config_context, Jinja syntax is a literal string.
+
+    The off state that gives the rendering tests below their meaning, and the
+    documented default: rendering is experimental (settings.py:92).
+    """
+    device = device_factory(
+        address="10.0.0.85/24",
+        serial="SN-RAW",
+        config_context={"zabbix": {"usermacros": {"{$SERIAL}": "{{ data.serial }}"}}},
+    )
+
+    run_sync(device.name, usermacro_sync=True, device_usermacro_map={})
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    assert macro_values(host)["{$SERIAL}"] == "{{ data.serial }}", (
+        "config context was rendered despite render_config_context=False"
+    )
+
+
+def test_jinja_renders_netbox_field_into_macro(device_factory, run_sync, zabbix_host):
+    """render_config_context=True resolves `data.serial` from the real device."""
+    device = device_factory(
+        address="10.0.0.86/24",
+        serial="SN-RENDERED",
+        config_context={"zabbix": {"usermacros": {"{$SERIAL}": "{{ data.serial }}"}}},
+    )
+
+    run_sync(
+        device.name,
+        render_config_context=True,
+        usermacro_sync=True,
+        device_usermacro_map={},
+    )
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    assert macro_values(host)["{$SERIAL}"] == "SN-RENDERED"
+
+
+def test_jinja_renders_nested_netbox_data_into_tags(
+    device_factory, run_sync, zabbix_host
+):
+    """Rendering reaches nested NetBox data, and feeds the tag path too.
+
+    `data.site.name` proves the device dict Jinja gets keeps its nested
+    objects, which is the difference between config context rendering being
+    useful and being a string formatter.
+    """
+    device = device_factory(
+        address="10.0.0.87/24",
+        config_context={"zabbix": {"tags": [{"site": "{{ data.site.name }}"}]}},
+    )
+
+    run_sync(
+        device.name,
+        render_config_context=True,
+        tag_sync=True,
+        tag_name=False,
+        device_tag_map={},
+    )
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    assert tag_pairs(host) == {("site", "ams-01")}
+
+
+def test_jinja_custom_filter_transforms_netbox_data(
+    device_factory, run_sync, zabbix_host
+):
+    """The bundled custom filters are loaded into the Jinja environment.
+
+    `regex_replace` comes from jinja_filters and is registered by name at
+    render time (tools.py:89). If that registration broke, this raises inside
+    Jinja rather than returning the wrong string -- so the failure is the
+    host's absence, not a bad value.
+    """
+    device = device_factory(
+        address="10.0.0.88/24",
+        serial="SN-ABC-123",
+        config_context={
+            "zabbix": {
+                "usermacros": {
+                    "{$SHORT_SERIAL}": "{{ data.serial | regex_replace('^SN-', '') }}"
+                }
+            }
+        },
+    )
+
+    run_sync(
+        device.name,
+        render_config_context=True,
+        usermacro_sync=True,
+        device_usermacro_map={},
+    )
+
+    host = zabbix_host(device.name)
+    assert host is not None, "custom filter failed to load; the render raised"
+    assert macro_values(host)["{$SHORT_SERIAL}"] == "ABC-123"
+
+
+def test_jinja_ipaddr_filter_available(device_factory, run_sync, zabbix_host):
+    """The j2ipaddr filters are loaded alongside the local ones.
+
+    They come from a separate package and a separate `filters.update` call
+    (tools.py:88), so one can be lost without the other noticing.
+    """
+    device = device_factory(
+        address="10.0.0.89/24",
+        config_context={
+            "zabbix": {
+                "usermacros": {
+                    "{$NETMASK}": "{{ data.primary_ip4.address | ip_netmask }}"
+                }
+            }
+        },
+    )
+
+    run_sync(
+        device.name,
+        render_config_context=True,
+        usermacro_sync=True,
+        device_usermacro_map={},
+    )
+
+    host = zabbix_host(device.name)
+    assert host is not None, "j2ipaddr filters failed to load; the render raised"
+    assert macro_values(host)["{$NETMASK}"] == "255.255.255.0"
+
+
+def test_jinja_conditional_builds_context(device_factory, run_sync, zabbix_host):
+    """Jinja control flow works, not just interpolation.
+
+    Rendering templates the *serialised JSON* of the zabbix key, so a
+    conditional has to survive being embedded in a JSON string and parsed back
+    (tools.py:91-93). That round trip is the part worth testing.
+    """
+    device = device_factory(
+        address="10.0.0.90/24",
+        status="active",
+        config_context={
+            "zabbix": {
+                "usermacros": {
+                    "{$MONITORED}": "{% if data.status.value == 'active' %}yes{% else %}no{% endif %}"
+                }
+            }
+        },
+    )
+
+    run_sync(
+        device.name,
+        render_config_context=True,
+        usermacro_sync=True,
+        device_usermacro_map={},
+    )
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    assert macro_values(host)["{$MONITORED}"] == "yes"
+
+
+def test_broken_jinja_skips_host_without_killing_the_run(
+    device_factory, sync_runner, zabbix_host
+):
+    """A device whose context will not render is skipped; the run continues.
+
+    Both devices are in one sync. The broken one references a filter that does
+    not exist, so its render raises and core.py:198-210 skips it -- and the
+    healthy device must still be synced, or one bad config context would take
+    down every host behind it in the loop.
+    """
+    broken = device_factory(
+        address="10.0.0.91/24",
+        config_context={
+            "zabbix": {"usermacros": {"{$X}": "{{ data | no_such_filter }}"}}
+        },
+    )
+    # The healthy device needs a zabbix config context of its own: with
+    # rendering on, a device without one is skipped too, which would make this
+    # test pass for the wrong reason. See test_rendering_skips_hosts_with_no_zabbix_context.
+    healthy = device_factory(
+        address="10.0.0.92/24",
+        config_context={"zabbix": {"usermacros": {"{$OK}": "yes"}}},
+    )
+
+    sync_runner(
+        device_filter={"name": [broken.name, healthy.name]},
+        render_config_context=True,
+        usermacro_sync=True,
+    )
+
+    assert zabbix_host(broken.name) is None, "host with unrenderable context was synced"
+    assert zabbix_host(healthy.name) is not None, (
+        "a broken config context stopped an unrelated device from syncing"
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "render_config_context=True skips every host whose config context has no "
+        "usable zabbix key. jinjafy_config_context returns {} for those "
+        "(tools.py:78-79, 96), and core.py:211 reads a falsy render as a failure "
+        "and skips the host. Remove this marker once an empty render leaves the "
+        "host's config context alone instead."
+    ),
+)
+@pytest.mark.parametrize(
+    "context",
+    [
+        pytest.param(None, id="no-config-context"),
+        pytest.param({"zabbix": {}}, id="empty-zabbix-key"),
+        pytest.param({"other_app": {"key": "value"}}, id="no-zabbix-key"),
+    ],
+)
+def test_rendering_skips_hosts_with_no_zabbix_context(
+    device_factory, run_sync, zabbix_host, context
+):
+    """Turning rendering on must not stop unrelated devices from syncing.
+
+    Config context is shared with the rest of NetBox, and a `zabbix` key is not
+    something most devices have -- `no-config-context` is simply the default
+    device, which is to say the majority of a real inventory. All three of
+    these sync normally with rendering off.
+
+    With it on they are all skipped: an empty render is indistinguishable from
+    a failed one at core.py:211, so the feature quietly stops syncing every
+    host it has nothing to do. That makes the blast radius of the experimental
+    flag the whole inventory rather than the hosts using it.
+    """
+    device = device_factory(address="10.0.0.93/24", config_context=context)
+
+    run_sync(device.name, render_config_context=True)
+
+    assert zabbix_host(device.name) is not None, (
+        "rendering skipped a device over a config context it should ignore"
+    )

--- a/tests/functional/test_default_maps.py
+++ b/tests/functional/test_default_maps.py
@@ -28,6 +28,18 @@ from tests.functional.conftest import macro_values, tag_pairs
 
 pytestmark = pytest.mark.functional
 
+
+def default_map(name: str) -> dict[str, str]:
+    """A map out of DEFAULT_CONFIG, narrowed to the dict it is.
+
+    DEFAULT_CONFIG holds every setting, so its value type is the union of all of
+    them; the maps have to be narrowed before they can be walked.
+    """
+    value = DEFAULT_CONFIG[name]
+    assert isinstance(value, dict)
+    return value
+
+
 INVENTORY_MANUAL_CONFIG = {"inventory_sync": True, "inventory_mode": "manual"}
 
 # Set on the fully-populated device below, and asserted through the default map.
@@ -101,7 +113,7 @@ def test_default_device_inventory_map_reaches_zabbix(
 
     inventory = zabbix_host(populated_device.name)["inventory"]
     assert {
-        key: inventory[key] for key in DEFAULT_CONFIG["device_inventory_map"].values()
+        key: inventory[key] for key in default_map("device_inventory_map").values()
     } == {
         "asset_tag": populated_device.asset_tag,
         # No virtual chassis on this device: an absent *parent* is the one
@@ -175,6 +187,7 @@ def test_default_nb_url_macro_is_the_api_url_not_the_web_ui(
     run_sync(populated_device.name, usermacro_sync=True)
 
     nb_url = macro_values(zabbix_host(populated_device.name))["{$NB_URL}"]
+    assert nb_url is not None
     assert "/api/dcim/devices/" in nb_url
     assert nb_url == populated_device.url
 
@@ -204,7 +217,7 @@ def test_default_vm_inventory_map_reaches_zabbix(vm_factory, run_vm_sync, zabbix
 
     inventory = zabbix_host(vm.name)["inventory"]
     assert {
-        key: inventory[key] for key in DEFAULT_CONFIG["vm_inventory_map"].values()
+        key: inventory[key] for key in default_map("vm_inventory_map").values()
     } == {
         "deployment_status": "Active",
         "notes": COMMENTS,

--- a/tests/functional/test_default_maps.py
+++ b/tests/functional/test_default_maps.py
@@ -1,0 +1,271 @@
+"""The maps that ship in DEFAULT_CONFIG, against a real NetBox and Zabbix.
+
+Every other mapping test names its own map, which proves the *mechanism* works
+and says nothing about the twenty-odd mappings users actually get out of the
+box. Those have two ends, and both can rot without any test noticing:
+
+- **The Zabbix end.** An inventory key must be one of Zabbix's ~70 inventory
+  fields and a macro name must satisfy Zabbix's own grammar. A typo is an API
+  error at sync time, not a stored value -- so it breaks the user's run, not
+  ours, unless a real Zabbix is asked.
+- **The NetBox end.** A path like `device_type/manufacturer/name` is a claim
+  about the shape NetBox serialises, including how much of a related object it
+  nests. NetBox can change that in a minor release, and `field_mapper` walks
+  with `Record[key]`, which does not lazy-load what is missing.
+
+So these tests deliberately do *not* pass a map. They let DEFAULT_CONFIG apply
+and assert on what Zabbix stored, which is the only thing that can fail when the
+shipped defaults stop matching either end.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from netbox_zabbix_sync.modules.settings import DEFAULT_CONFIG
+from tests.functional.bootstrap import seed_netbox
+from tests.functional.conftest import macro_values, tag_pairs
+
+pytestmark = pytest.mark.functional
+
+INVENTORY_MANUAL_CONFIG = {"inventory_sync": True, "inventory_mode": "manual"}
+
+# Set on the fully-populated device below, and asserted through the default map.
+SERIAL = "SN-DEFAULTS-1"
+COMMENTS = "a note that lands in the Zabbix inventory"
+OOB_ADDRESS = "10.20.0.1/24"
+
+
+@pytest.fixture
+def placement(nb, seeded):
+    """A location, rack and platform for a device to sit in, cleaned up after.
+
+    Only the default-map tests need these: they exist to populate the paths the
+    shipped `device_inventory_map` and `device_tag_map` name (`location/name`,
+    `rack/name`, `platform/name`), which a bare device leaves empty and which
+    would therefore prove nothing about whether the path resolves.
+    """
+    suffix = uuid4().hex[:8]
+    location = nb.dcim.locations.create(
+        name=f"loc-{suffix}", slug=f"loc-{suffix}", site=seeded["site"].id
+    )
+    rack = nb.dcim.racks.create(
+        name=f"rack-{suffix}", site=seeded["site"].id, location=location.id
+    )
+    platform = nb.dcim.platforms.create(name=f"plat-{suffix}", slug=f"plat-{suffix}")
+
+    yield {"location": location, "rack": rack, "platform": platform}
+
+    # NetBox refuses to delete a rack with a device still in it, so these can
+    # only go after device_factory's teardown. Finalizers run in reverse setup
+    # order, which is why `populated_device` requests this fixture *before*
+    # device_factory: that makes device_factory the later setup and so the
+    # earlier teardown.
+    for obj in (rack, location, platform):
+        obj.delete()
+
+
+@pytest.fixture
+def populated_device(placement, device_factory, seeded):
+    """A device with every field the default device maps name actually set.
+
+    Argument order matters here; see the note in `placement`'s teardown.
+    """
+    return device_factory(
+        address="10.20.1.1/24",
+        oob_address=OOB_ADDRESS,
+        location=placement["location"].id,
+        rack=placement["rack"].id,
+        position=1,
+        face="front",
+        platform=placement["platform"].id,
+        serial=SERIAL,
+        asset_tag=f"AT-{placement['rack'].name}",
+        comments=COMMENTS,
+        latitude="52.370216",
+        longitude="4.895168",
+    )
+
+
+def test_default_device_inventory_map_reaches_zabbix(
+    populated_device, placement, run_sync, zabbix_host
+):
+    """The shipped map, unmodified, against a device that populates all of it.
+
+    Asserting every entry rather than a sample: the point is the map as
+    shipped, and a spot check would leave the other ten free to rot. A wrong
+    Zabbix key fails this test by erroring the sync, a wrong NetBox path by
+    landing an empty value.
+    """
+    run_sync(populated_device.name, **INVENTORY_MANUAL_CONFIG)
+
+    inventory = zabbix_host(populated_device.name)["inventory"]
+    assert {
+        key: inventory[key] for key in DEFAULT_CONFIG["device_inventory_map"].values()
+    } == {
+        "asset_tag": populated_device.asset_tag,
+        # No virtual chassis on this device: an absent *parent* is the one
+        # missing-data case field_mapper handles, mapping it to "".
+        "chassis": "",
+        "deployment_status": "Active",
+        "location": placement["location"].name,
+        "location_lat": "52.370216",
+        "location_lon": "4.895168",
+        "notes": COMMENTS,
+        "name": populated_device.name,
+        "site_rack": placement["rack"].name,
+        "serialno_a": SERIAL,
+        "type": seed_netbox.DEVICE_TYPE_MODEL,
+        "vendor": seed_netbox.MANUFACTURER_NAME,
+        "oob_ip": OOB_ADDRESS,
+    }
+
+
+def test_default_device_inventory_map_survives_a_bare_device(
+    device_factory, run_sync, zabbix_host
+):
+    """The common case: a device with none of the optional fields set.
+
+    Every nullable path in the shipped map has to map to "" rather than raise,
+    or the run ends on the first sparsely-filled device -- which, given the map
+    names a rack, a location, an asset tag and an OOB IP, is most of them.
+    """
+    device = device_factory()
+
+    run_sync(device.name, **INVENTORY_MANUAL_CONFIG)
+
+    host = zabbix_host(device.name)
+    assert host is not None, "a device with only required fields did not sync"
+    assert host["inventory"]["name"] == device.name
+    assert host["inventory"]["site_rack"] == ""
+
+
+def test_default_device_usermacro_map_reaches_zabbix(
+    populated_device, run_sync, zabbix_host
+):
+    """Every shipped macro name must satisfy Zabbix's grammar, not just ours.
+
+    `ZabbixUsermacros.validate_macro` is the project's own regex; it is not
+    Zabbix's. A name that passes ours and fails Zabbix's is an API error, and
+    only a real Zabbix can tell the two apart.
+    """
+    run_sync(populated_device.name, usermacro_sync=True)
+
+    macros = macro_values(zabbix_host(populated_device.name))
+    assert macros == {
+        "{$HW_SERIAL}": SERIAL,
+        "{$DEV_ROLE}": seed_netbox.ROLE_NAME,
+        "{$NB_URL}": populated_device.url,
+        "{$NB_ID}": str(populated_device.id),
+    }
+
+
+def test_default_nb_url_macro_is_the_api_url_not_the_web_ui(
+    populated_device, run_sync, zabbix_host
+):
+    """Pinning a surprise in the shipped map rather than endorsing it.
+
+    `{$NB_URL}` maps from `url`, which pynetbox and NetBox both use for the
+    *API* endpoint of the object. Someone clicking this macro in Zabbix expecting
+    the device's page gets JSON instead. NetBox serves the UI address separately
+    as `display_url`, so the fix -- if it is one -- is a map change, not a code
+    change. Left as-is because changing it would move every existing user's
+    macro; the test is here so the choice is visible.
+    """
+    run_sync(populated_device.name, usermacro_sync=True)
+
+    nb_url = macro_values(zabbix_host(populated_device.name))["{$NB_URL}"]
+    assert "/api/dcim/devices/" in nb_url
+    assert nb_url == populated_device.url
+
+
+def test_default_device_tag_map_reaches_zabbix(
+    populated_device, placement, run_sync, zabbix_host
+):
+    """The shipped tag map, with tag_name off so only mapped tags are present.
+
+    `tag_name` defaults to "NetBox" and would add a tag per NetBox tag on top of
+    the map's, which is a different feature; it is turned off here so this test
+    fails for map reasons only.
+    """
+    run_sync(populated_device.name, tag_sync=True, tag_name=None)
+
+    assert tag_pairs(zabbix_host(populated_device.name)) == {
+        ("site", seed_netbox.SITE_NAME.lower()),
+        ("rack", placement["rack"].name.lower()),
+        ("target", placement["platform"].name.lower()),
+    }
+
+
+def test_default_vm_inventory_map_reaches_zabbix(vm_factory, run_vm_sync, zabbix_host):
+    vm = vm_factory(comments=COMMENTS)
+
+    run_vm_sync(vm.name, **INVENTORY_MANUAL_CONFIG)
+
+    inventory = zabbix_host(vm.name)["inventory"]
+    assert {
+        key: inventory[key] for key in DEFAULT_CONFIG["vm_inventory_map"].values()
+    } == {
+        "deployment_status": "Active",
+        "notes": COMMENTS,
+        "name": vm.name,
+    }
+
+
+def test_default_vm_usermacro_map_reaches_zabbix(vm_factory, run_vm_sync, zabbix_host):
+    vm = vm_factory(memory=4096)
+
+    run_vm_sync(vm.name, usermacro_sync=True)
+
+    assert macro_values(zabbix_host(vm.name)) == {
+        "{$TOTAL_MEMORY}": "4096",
+        "{$DEV_ROLE}": seed_netbox.ROLE_NAME,
+        "{$NB_URL}": vm.url,
+        "{$NB_ID}": str(vm.id),
+    }
+
+
+def test_default_vm_tag_map_reaches_zabbix(vm_factory, run_vm_sync, zabbix_host):
+    """`platform/name` is in the shipped map but this VM has no platform.
+
+    Left unset deliberately: a VM without a platform is ordinary, and the tag
+    that cannot be built has to be dropped rather than raise or land empty.
+    `render_tag` rejects the empty value (tags.py:63), which is why `target` is
+    absent here instead of present and blank.
+    """
+    vm = vm_factory()
+
+    run_vm_sync(vm.name, tag_sync=True, tag_name=None)
+
+    assert tag_pairs(zabbix_host(vm.name)) == {
+        ("site", seed_netbox.SITE_NAME.lower()),
+        ("cluster", seed_netbox.CLUSTER_NAME.lower()),
+    }
+
+
+def test_hostgroup_reaches_cluster_type_but_a_map_cannot(
+    vm_factory, run_vm_sync, zabbix_host
+):
+    """The same NetBox field, reachable one way and not the other.
+
+    `vm_hostgroup_format` resolves `cluster_type` via `self.nb.cluster.type.name`
+    (hostgroups.py:88) -- attribute access, so pynetbox lazily fetches the full
+    cluster and the field is there. A map naming the same field as
+    `cluster/type/name` goes through `field_mapper`, which walks with
+    `Record[key]`; that is `dict(self)[key]`, it does not lazy-load, and NetBox
+    does not nest `type` inside the cluster it returns on a VM.
+
+    So the field is simultaneously available and unavailable depending on which
+    feature asks. The map does not merely miss it -- the KeyError escapes
+    `Sync.start()` and ends the run, which is the bug pinned in
+    test_extended_models.py::test_unextended_mapped_field_aborts_the_run. Here
+    the hostgroup half is asserted as the contrast; the map half is left to that
+    test rather than duplicating an xfail.
+    """
+    vm = vm_factory()
+
+    run_vm_sync(vm.name)
+
+    groups = [group["name"] for group in zabbix_host(vm.name)["hostgroups"]]
+    assert groups == [seed_netbox.EXPECTED_VM_HOSTGROUP]
+    assert seed_netbox.CLUSTER_TYPE_NAME in groups[0]

--- a/tests/functional/test_descriptions.py
+++ b/tests/functional/test_descriptions.py
@@ -1,0 +1,256 @@
+"""The Zabbix host description, which is built entirely from settings.
+
+`description` is unusual among the settings: it is not a boolean or a map but a
+small template language. It takes one of two named defaults ("static",
+"dynamic"), a literal `False` meaning empty, or an arbitrary string that may
+contain `{datetime}` and `{owner}` macros -- and any of those four can be
+overridden per host from the config context. `description_dt_format` then
+controls how `{datetime}` renders.
+
+The failure mode worth testing is the quiet one: an unknown macro does not fail
+the host, it silently falls back to the static default (host_description.py:70).
+A test that only checked "some description arrived" would pass for every one of
+those fallbacks, so each test below asserts the exact string.
+"""
+
+from datetime import datetime
+
+import pytest
+
+pytestmark = pytest.mark.functional
+
+STATIC_DEFAULT = "Host added by NetBox sync script."
+
+
+def description_of(host: dict) -> str:
+    return host["description"]
+
+
+def test_static_is_the_default(device_factory, run_sync, zabbix_host):
+    """No `description` setting at all still produces the static text."""
+    device = device_factory()
+
+    run_sync(device.name)
+
+    assert description_of(zabbix_host(device.name)) == STATIC_DEFAULT
+
+
+def test_description_false_produces_an_empty_description(
+    device_factory, run_sync, zabbix_host
+):
+    """`False` is a real option, distinct from unset (host_description.py:110).
+
+    Worth its own test because `False` and "unset" are both falsy in Python but
+    mean opposite things here: unset gives the static default, `False` gives an
+    empty string.
+    """
+    device = device_factory()
+
+    run_sync(device.name, description=False)
+
+    assert description_of(zabbix_host(device.name)) == ""
+
+
+def test_dynamic_resolves_both_macros(device_factory, run_sync, zabbix_host):
+    """ "dynamic" is the other named default, and it exercises both macros.
+
+    The date is asserted rather than the full timestamp: minutes and seconds
+    are a race against the clock between the sync and the assertion, but the
+    date is not. Checking the prefix and suffix around it pins the template's
+    shape without pinning the moment it ran.
+    """
+    device = device_factory()
+
+    run_sync(device.name, description="dynamic")
+
+    description = description_of(zabbix_host(device.name))
+    assert description.startswith("Host by owner ")
+    assert " added by NetBox sync script on " in description
+    assert datetime.now().strftime("%Y-%m-%d") in description
+    # No macro survived unresolved -- the fallback would have replaced the
+    # whole string with the static default, but a partial resolve would not.
+    assert "{" not in description
+
+
+def test_a_custom_description_is_used_verbatim(device_factory, run_sync, zabbix_host):
+    """Any string that is not a named default is the description itself."""
+    device = device_factory()
+
+    run_sync(device.name, description="Managed by the network team")
+
+    assert description_of(zabbix_host(device.name)) == "Managed by the network team"
+
+
+def test_custom_dt_format_changes_how_datetime_renders(
+    device_factory, run_sync, zabbix_host
+):
+    """`description_dt_format` is read, not just accepted.
+
+    A year-only format is used so the expected value is exact and stable: a
+    format including minutes would leave this test racing the clock.
+    """
+    device = device_factory()
+
+    run_sync(
+        device.name,
+        description="synced in {datetime}",
+        description_dt_format="%Y",
+    )
+
+    expected = f"synced in {datetime.now().strftime('%Y')}"
+    assert description_of(zabbix_host(device.name)) == expected
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "A meaningless datetime format reaches Zabbix verbatim. The guard at "
+        "host_description.py:39-49 catches ValueError/TypeError around "
+        "`strftime`, but `strftime` does not validate directives -- an unknown "
+        "one like %Q is passed through literally rather than raising -- so the "
+        "ValueError arm is unreachable and only a non-str format (TypeError) "
+        "ever hits the fallback. The user gets a Zabbix description containing "
+        "their format string instead of a date, with nothing logged. Remove "
+        "this marker once the format is validated up front; see ISSUES.md "
+        "issue 6."
+    ),
+)
+def test_a_meaningless_dt_format_falls_back_to_the_default(
+    device_factory, run_sync, zabbix_host
+):
+    """A format that cannot render a date should fall back, as a bad type does.
+
+    Asserted as "a real date arrived", which is what the existing fallback
+    produces for the `TypeError` case (see the test below). The two inputs are
+    the same user error -- a `description_dt_format` that cannot produce a
+    datetime -- so they should reach the same place.
+    """
+    device = device_factory()
+
+    run_sync(
+        device.name,
+        description="synced in {datetime}",
+        description_dt_format="%Q-not-a-format",
+    )
+
+    description = description_of(zabbix_host(device.name))
+    assert description.startswith("synced in ")
+    assert datetime.now().strftime("%Y-%m-%d") in description
+
+
+def test_a_non_string_dt_format_hits_the_guard_and_falls_back(
+    device_factory, run_sync, zabbix_host
+):
+    """The reachable half of the guard: `TypeError`, not `ValueError`.
+
+    `strftime` rejects a non-str argument, which is the case a config.py can
+    produce by assigning a number or leaving the value None. The fallback to
+    the default format is what keeps the host syncing, so the assertion is that
+    a real date arrived.
+    """
+    device = device_factory()
+
+    run_sync(
+        device.name,
+        description="synced in {datetime}",
+        description_dt_format=None,
+    )
+
+    description = description_of(zabbix_host(device.name))
+    assert description.startswith("synced in ")
+    assert datetime.now().strftime("%Y-%m-%d") in description
+
+
+def test_unknown_macro_falls_back_to_static(device_factory, run_sync, zabbix_host):
+    """The quiet failure: one bad macro discards the whole custom description.
+
+    Not a partial render and not an error -- the entire string is replaced by
+    the static default (host_description.py:70,119). Asserted exactly, because
+    a test that merely checked the macro was gone would pass for a render that
+    dropped only the macro.
+    """
+    device = device_factory()
+
+    run_sync(device.name, description="site is {site} at {datetime}")
+
+    assert description_of(zabbix_host(device.name)) == STATIC_DEFAULT
+
+
+def test_config_context_overrides_the_configured_description(
+    device_factory, run_sync, zabbix_host
+):
+    """A per-host description beats the global setting.
+
+    Both are set, to different values, so this fails if the precedence is the
+    other way round rather than merely proving the context was read.
+    """
+    device = device_factory(
+        config_context={"zabbix": {"description": "this host is special"}}
+    )
+
+    run_sync(device.name, description="the global default")
+
+    assert description_of(zabbix_host(device.name)) == "this host is special"
+
+
+def test_config_context_description_resolves_macros_too(
+    device_factory, run_sync, zabbix_host
+):
+    """The override goes through the same macro resolution as the setting.
+
+    Easy to get wrong in the other direction -- returning the context value
+    untouched would leave a literal `{datetime}` on the Zabbix host.
+    """
+    device = device_factory(
+        config_context={"zabbix": {"description": "built {datetime}"}}
+    )
+
+    run_sync(device.name, description_dt_format="%Y")
+
+    expected = f"built {datetime.now().strftime('%Y')}"
+    assert description_of(zabbix_host(device.name)) == expected
+
+
+def test_bad_macro_in_config_context_falls_back_to_static(
+    device_factory, run_sync, zabbix_host
+):
+    """The override falls back to the *static* default, not to the setting.
+
+    A user with `description = "the global default"` and a typo in one host's
+    config context gets the static text on that host, not their configured
+    description (host_description.py:100). Pinned because it is the kind of
+    precedence a reasonable person would guess the other way.
+    """
+    device = device_factory(config_context={"zabbix": {"description": "{nonsense}"}})
+
+    run_sync(device.name, description="the global default")
+
+    assert description_of(zabbix_host(device.name)) == STATIC_DEFAULT
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "The description is written once at host creation and never reconciled. "
+        "`Description.generate()` is called only from `create_in_zabbix` "
+        "(host.py:698-714); `consistency_check` compares status, templates, "
+        "groups, interfaces, inventory, macros, tags and proxy, but not the "
+        "description. So on any installation whose hosts already exist -- which "
+        "is every installation past its first run -- editing `description` or "
+        "`description_dt_format` silently does nothing. Remove this marker once "
+        "consistency_check compares the description. Note that a fix has to "
+        "keep `{datetime}` stable, or every host is rewritten on every run and "
+        "'added on <date>' stops being true; see ISSUES.md issue 5."
+    ),
+)
+def test_a_changed_description_reaches_an_existing_host(
+    device_factory, run_sync, zabbix_host
+):
+    """Changing the setting should reach a host Zabbix already has."""
+    device = device_factory()
+    run_sync(device.name)
+    assert description_of(zabbix_host(device.name)) == STATIC_DEFAULT
+
+    run_sync(device.name, description="changed on the second run")
+
+    assert description_of(zabbix_host(device.name)) == "changed on the second run"

--- a/tests/functional/test_extended_models.py
+++ b/tests/functional/test_extended_models.py
@@ -1,0 +1,354 @@
+"""The extended_* settings, which change what NetBox returns rather than what we do.
+
+NetBox serves related objects on a device in a *nested* form carrying only a
+handful of fields. `extended_site_properties`, `extended_virtual_chassis` and
+`extended_ips` each call `full_details()` on one of them, trading extra API
+requests for the rest of the fields -- which then become available to the
+inventory, usermacro and tag maps.
+
+This is the one group of features a mocked test cannot express an opinion
+about, in either direction:
+
+- A DummyNB has whatever fields the test gave it, so a mocked map over
+  `site/latitude` passes whether or not the flag is on. The flag's entire
+  effect is on data that arrives from NetBox.
+- Which fields are nested and which are not is NetBox's decision, and it
+  changes between versions. `primary_ip4.dns_name`, for one, is nested
+  already -- so extending IPs is *not* what makes DNS available, despite that
+  being the documented reason for the setting.
+
+Two behaviours found while writing these are worth knowing before reading on,
+because they are why the tests are not the symmetrical off/on pairs you would
+expect. Both come from one pynetbox detail: a nested `Record` lazily fetches
+its full details on *attribute* access (`site.latitude`), but `Record[key]`
+is `dict(self)[key]` and does no such thing.
+
+1. `field_mapper` walks with `value[item]` (tools.py:130), so a mapped field
+   NetBox did not nest raises `KeyError` rather than mapping to "". It escapes
+   `start()`, which only catches `SyncError`, and takes the whole run down --
+   see `test_unextended_mapped_field_aborts_the_run`.
+2. `extended_site_properties` is redundant for devices: `Hostgroup` reads
+   `self.nb.site.region` (hostgroups.py:64) for every device with a site,
+   which lazily fetches the site anyway -- see
+   `test_site_is_fetched_even_without_extended_site_properties`.
+"""
+
+from urllib.parse import urlparse
+
+import pytest
+
+from tests.functional.bootstrap.seed_netbox import SITE_LATITUDE, SITE_LONGITUDE
+from tests.functional.conftest import macro_values
+
+INVENTORY_MANUAL_CONFIG = {"inventory_sync": True, "inventory_mode": "manual"}
+
+# Devices synced by test_site_costs_one_fetch_per_host_either_way, which
+# expects the site to be fetched exactly once for each of them.
+SYNCED_HOSTS = 2
+
+# field_mapper indexes rather than getattrs, so it never triggers pynetbox's
+# lazy fetch and a field that was not nested is simply missing. The KeyError
+# that follows is not caught anywhere: start() handles SyncError only, so one
+# such field in the map ends the entire run, not just that host. Mapping an
+# absent field is already handled for empty values (tools.py:135) -- an absent
+# key looks like the same intent.
+UNEXTENDED_FIELD_BUG = (
+    "field_mapper raises KeyError on a mapped field that NetBox did not nest, "
+    "aborting the whole run instead of mapping it to an empty string "
+    "(tools.py:130). Remove this marker once it maps to '' like an empty value."
+)
+
+
+def site_detail_requests(exchanges, site_id: int):
+    """The recorded requests that fetched this site's full details."""
+    path = f"/api/dcim/sites/{site_id}/"
+    return [ex for ex in exchanges if urlparse(ex.url).path == path]
+
+
+# --- the mapped-but-absent field --------------------------------------------
+
+
+@pytest.mark.xfail(strict=True, reason=UNEXTENDED_FIELD_BUG)
+def test_unextended_mapped_field_aborts_the_run(
+    device_factory, virtual_chassis_factory, run_sync, zabbix_host
+):
+    """A field that needs extending, mapped without it, should be skipped.
+
+    `virtual_chassis/domain` is not on the nested chassis, and the flag that
+    would fetch it is off -- the same shape as a user who copied a map out of
+    the wiki and forgot the setting, or who upgraded into a NetBox that nests
+    one field fewer.
+
+    What should happen is what happens for a field that is present but empty:
+    an empty inventory value, host synced. What happens instead is a KeyError
+    out of `Sync.start()` that ends the run, so every host queued behind this
+    one goes unsynced too.
+    """
+    device = device_factory(address="10.0.0.130/24")
+    virtual_chassis_factory(device, domain="chassis.example.com")
+
+    run_sync(
+        device.name,
+        **INVENTORY_MANUAL_CONFIG,
+        device_inventory_map={"virtual_chassis/domain": "chassis", "name": "name"},
+    )
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    assert host["inventory"]["chassis"] == ""
+
+
+# --- extended_site_properties -----------------------------------------------
+
+
+def test_site_is_fetched_even_without_extended_site_properties(
+    device_factory, seeded, sync_runner, netbox_requests, zabbix_host
+):
+    """The flag is redundant for devices: the site is fetched either way.
+
+    `Hostgroup` reads `self.nb.site.region` for every device that has a site
+    (hostgroups.py:63-71), and that attribute is not nested, so pynetbox
+    fetches the full site to answer it. By the time the inventory map runs, the
+    geo data is already on the record.
+
+    So the config file's warning that this setting "will increase the number of
+    API queries" does not hold for devices, and neither does needing it to map
+    `site/latitude`. Pinned rather than left implicit because the day pynetbox
+    stops lazy-loading, every user mapping site geo without the flag starts
+    hitting the KeyError above -- and this test is where that shows up.
+    """
+    device = device_factory(address="10.0.0.100/24")
+
+    sync_runner(
+        device_filter={"name": device.name},
+        **INVENTORY_MANUAL_CONFIG,
+        extended_site_properties=False,
+        device_inventory_map={"site/latitude": "location_lat", "name": "name"},
+    )
+
+    assert site_detail_requests(netbox_requests, seeded["site"].id), (
+        "the site was not fetched; the lazy load this test documents is gone "
+        "and mapping site/latitude without the flag now raises KeyError"
+    )
+    host = zabbix_host(device.name)
+    assert host is not None
+    assert host["inventory"]["location_lat"] == SITE_LATITUDE
+
+
+def test_site_geo_synced_with_extended_site_properties(
+    device_factory, run_sync, zabbix_host
+):
+    """With the flag on, the site's geo data reaches Zabbix inventory.
+
+    This is the documented reason the setting exists: the default inventory map
+    ships `latitude`/`longitude` commented out in favour of `site/latitude`.
+    """
+    device = device_factory(address="10.0.0.101/24")
+
+    run_sync(
+        device.name,
+        **INVENTORY_MANUAL_CONFIG,
+        extended_site_properties=True,
+        device_inventory_map={
+            "site/latitude": "location_lat",
+            "site/longitude": "location_lon",
+            "name": "name",
+        },
+    )
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    inventory = host["inventory"]
+    assert inventory["location_lat"] == SITE_LATITUDE
+    assert inventory["location_lon"] == SITE_LONGITUDE
+
+
+@pytest.mark.parametrize("extended", [False, True], ids=["flag-off", "flag-on"])
+def test_site_costs_one_fetch_per_host_either_way(
+    device_factory, seeded, sync_runner, netbox_requests, zabbix_host, extended
+):
+    """The site is fetched once per host whether the flag is set or not.
+
+    The measured cost of `extended_site_properties` on devices, and it is
+    nothing: two devices, two site fetches, with the flag off and with it on.
+    Each device deserialises its own site Record, so `has_details` is not
+    shared and there is no run-level caching to lose -- the flag simply moves
+    who triggers the fetch, from `Hostgroup` to `core.start`.
+
+    Which means the config file's warning that this setting "will increase the
+    number of API queries" does not describe devices. It is also the N+1 this
+    would need if the fetch ever became conditional: one site, one request per
+    host.
+    """
+    first = device_factory(address="10.0.0.102/24")
+    second = device_factory(address="10.0.0.103/24")
+
+    sync_runner(
+        device_filter={"name": [first.name, second.name]},
+        **INVENTORY_MANUAL_CONFIG,
+        extended_site_properties=extended,
+        device_inventory_map={"site/latitude": "location_lat", "name": "name"},
+    )
+
+    assert zabbix_host(first.name) is not None
+    assert zabbix_host(second.name) is not None
+    assert len(site_detail_requests(netbox_requests, seeded["site"].id)) == SYNCED_HOSTS
+
+
+# --- extended_virtual_chassis -----------------------------------------------
+
+
+def test_virtual_chassis_name_needs_no_extension(
+    device_factory, virtual_chassis_factory, run_sync, zabbix_host
+):
+    """The default map's `virtual_chassis/name` works with the flag off.
+
+    Worth pinning: it means the default configuration is not silently relying
+    on a setting that defaults to False. `name` is nested; `domain` is not,
+    which is the next test.
+    """
+    device = device_factory(address="10.0.0.110/24")
+    vc = virtual_chassis_factory(device, domain="chassis.example.com")
+
+    run_sync(device.name, **INVENTORY_MANUAL_CONFIG)
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    assert host["inventory"]["chassis"] == vc.name
+
+
+def test_chassis_domain_synced_with_extended_virtual_chassis(
+    device_factory, virtual_chassis_factory, run_sync, zabbix_host
+):
+    """extended_virtual_chassis makes the chassis' own fields mappable."""
+    device = device_factory(address="10.0.0.112/24")
+    virtual_chassis_factory(device, domain="chassis.example.com")
+
+    run_sync(
+        device.name,
+        **INVENTORY_MANUAL_CONFIG,
+        extended_virtual_chassis=True,
+        device_inventory_map={"virtual_chassis/domain": "chassis", "name": "name"},
+    )
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    assert host["inventory"]["chassis"] == "chassis.example.com"
+
+
+def test_chassis_members_available_to_jinja_when_extended(
+    device_factory, virtual_chassis_factory, sync_runner, zabbix_host
+):
+    """The extended chassis carries its members, which Jinja can walk.
+
+    `members` is absent from the nested chassis entirely, so this is the
+    feature at its most useful: building a macro out of NetBox relations that
+    the device itself does not carry. core.py:404-407 extends each member too,
+    which is what lets the template reach a member's own fields.
+    """
+    master = device_factory(
+        address="10.0.0.113/24",
+        config_context={
+            "zabbix": {
+                "usermacros": {
+                    "{$CHASSIS_MEMBERS}": "{{ data.virtual_chassis.members | length }}"
+                }
+            }
+        },
+    )
+    member = device_factory(address="10.0.0.114/24")
+    virtual_chassis_factory(master, member)
+
+    sync_runner(
+        device_filter={"name": master.name},
+        extended_virtual_chassis=True,
+        render_config_context=True,
+        usermacro_sync=True,
+        device_usermacro_map={},
+    )
+
+    host = zabbix_host(master.name)
+    assert host is not None
+    assert macro_values(host)["{$CHASSIS_MEMBERS}"] == "2"
+
+
+def test_clustering_promotes_master_to_chassis_name(
+    device_factory, virtual_chassis_factory, sync_runner, zabbix_host
+):
+    """With clustering on, the chassis syncs as one host named for the chassis.
+
+    A stack of switches is one monitored thing, not N. The master is promoted
+    to the chassis name (device.py:57) and the secondary member gets no host of
+    its own -- assert both, since a sync that created nothing would satisfy
+    only the second.
+    """
+    master = device_factory(address="10.0.0.115/24")
+    member = device_factory(address="10.0.0.116/24")
+    vc = virtual_chassis_factory(master, member)
+
+    sync_runner(device_filter={"name": [master.name, member.name]}, clustering=True)
+
+    assert zabbix_host(vc.name) is not None, "master was not promoted to chassis name"
+    assert zabbix_host(master.name) is None, "master synced under its own name too"
+    assert zabbix_host(member.name) is None, "secondary member got its own host"
+
+
+# --- extended_ips -----------------------------------------------------------
+
+
+def test_ip_status_synced_with_extended_ips(device_factory, run_sync, zabbix_host):
+    """extended_ips exposes the IP's own fields to the maps.
+
+    `status` is not nested on an IP, so this needs the flag -- unlike
+    `dns_name`, which is nested and needs nothing, despite DNS being the
+    documented reason for the setting. Without the flag this map does not
+    yield "" but raises; that is `test_unextended_mapped_field_aborts_the_run`.
+    """
+    device = device_factory(address="10.0.0.121/24")
+
+    run_sync(
+        device.name,
+        **INVENTORY_MANUAL_CONFIG,
+        extended_ips=True,
+        device_inventory_map={"primary_ip4/status/label": "notes", "name": "name"},
+    )
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    assert host["inventory"]["notes"] == "Active"
+
+
+def test_oob_ip_address_needs_no_extension(device_factory, run_sync, zabbix_host):
+    """The default map's `oob_ip/address` works without extended_ips.
+
+    The nested IP carries its address, so the default inventory map is not
+    quietly dependent on a flag that defaults to False.
+    """
+    device = device_factory(address="10.0.0.122/24", oob_address="192.168.1.122/24")
+
+    run_sync(device.name, **INVENTORY_MANUAL_CONFIG)
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    assert host["inventory"]["oob_ip"] == "192.168.1.122/24"
+
+
+def test_dns_name_used_for_interface_when_preferred(
+    device_factory, run_sync, zabbix_host
+):
+    """prefer_dns points the Zabbix interface at the IP's DNS name.
+
+    Included here because it is the behaviour extended_ips is documented to
+    enable, and it turns out to need neither the flag nor an extra request:
+    dns_name is nested. The interface flips to useip=0 and Zabbix monitors the
+    name (interface.py:17).
+    """
+    device = device_factory(address="10.0.0.123/24", dns_name="host123.example.com")
+
+    run_sync(device.name, prefer_dns=True)
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    interface = host["interfaces"][0]
+    assert interface["useip"] == "0", "interface still uses the IP despite prefer_dns"
+    assert interface["dns"] == "host123.example.com"

--- a/tests/functional/test_host_attributes.py
+++ b/tests/functional/test_host_attributes.py
@@ -443,3 +443,158 @@ def test_empty_netbox_field_becomes_empty_inventory_value(
     host = zabbix_host(device.name)
     assert host is not None, "a device with an empty serial failed to sync"
     assert host["inventory"]["serialno_a"] == ""
+
+
+# --- what a bad map does ----------------------------------------------------
+
+
+def test_unknown_inventory_field_costs_only_its_own_host(
+    device_factory, vm_factory, sync_runner, zabbix_host
+):
+    """A map naming a field Zabbix does not have fails that host, not the run.
+
+    This is the same user error as the one in
+    test_extended_models.py::test_unextended_mapped_field_aborts_the_run -- a
+    typo in a map -- but on the Zabbix side of it, and the blast radius is
+    completely different. Zabbix rejects `host.create`, the sync catches it, logs
+    it and moves on; a NetBox path that does not resolve raises KeyError out of
+    `Sync.start()` and takes every remaining host with it.
+
+    The VM proves the run really continued rather than merely not raising: VMs
+    are synced before devices (core.py:348), so a broken VM that ended the run
+    would leave the device unsynced. Only the VM's map is broken, since a map is
+    config and applies to every host of its type -- which is the point.
+    """
+    vm = vm_factory()
+    device = device_factory(address="10.0.0.76/24")
+
+    sync_runner(
+        device_filter={"name": device.name},
+        vm_filter={"name": vm.name},
+        sync_vms=True,
+        inventory_sync=True,
+        inventory_mode="manual",
+        vm_inventory_map={"name": "not_a_zabbix_inventory_field"},
+        device_inventory_map={"name": "name"},
+    )
+
+    assert zabbix_host(vm.name) is None, "Zabbix accepted an invented inventory field"
+    device_host = zabbix_host(device.name)
+    assert device_host is not None, (
+        "the device never synced: one host's rejected inventory ended the run"
+    )
+    assert device_host["inventory"]["name"] == device.name
+
+
+def test_oversized_macro_value_is_dropped_not_sent(
+    device_factory, run_sync, zabbix_host
+):
+    """A value past Zabbix's 2048-byte macro limit is dropped before the call.
+
+    NetBox puts no such limit on the fields a map can name -- `comments` is a
+    free-text field -- so this is reachable with nothing but a verbose comment
+    and the shipped `comments` mapping. Zabbix would reject the whole host, so
+    the check in usermacros.py:104 has to drop the macro rather than log and
+    send: the assertion is that the host exists and kept its other macro.
+    """
+    device = device_factory(
+        address="10.0.0.77/24", comments="x" * 3000, serial="SN-SURVIVES"
+    )
+
+    run_sync(
+        device.name,
+        usermacro_sync=True,
+        device_usermacro_map={"comments": "{$TOO_BIG}", "serial": "{$OK}"},
+    )
+
+    host = zabbix_host(device.name)
+    assert host is not None, "an oversized macro value took the whole host down"
+    assert macro_values(host) == {"{$OK}": "SN-SURVIVES"}
+
+
+def test_macro_description_reaches_zabbix(device_factory, run_sync, zabbix_host):
+    """The dict form's `description` is stored, not just accepted.
+
+    Covered here rather than in test_usermacros_from_config_context because it
+    needs the description read back off the Zabbix host: the mocked suite can
+    only show it was put in the payload.
+    """
+    device = device_factory(
+        address="10.0.0.78/24",
+        config_context={
+            "zabbix": {
+                "usermacros": {
+                    "{$DOCUMENTED}": {"value": "1", "description": "why this exists"}
+                }
+            }
+        },
+    )
+
+    run_sync(device.name, usermacro_sync=True, device_usermacro_map={})
+
+    host = zabbix_host(device.name)
+    descriptions = {m["macro"]: m["description"] for m in host["macros"]}
+    assert descriptions["{$DOCUMENTED}"] == "why this exists"
+
+
+def test_macro_dict_without_a_value_is_skipped(device_factory, run_sync, zabbix_host):
+    """A dict form missing `value` is dropped rather than sent empty.
+
+    The distinction that makes this worth a test: a macro whose value is empty
+    would be created in Zabbix as a blank, silently overwriting whatever a
+    template set. usermacros.py:63 declines to guess.
+    """
+    device = device_factory(
+        address="10.0.0.79/24",
+        config_context={
+            "zabbix": {
+                "usermacros": {
+                    "{$NO_VALUE}": {"type": "text", "description": "no value here"},
+                    "{$FINE}": "yes",
+                }
+            }
+        },
+    )
+
+    run_sync(device.name, usermacro_sync=True, device_usermacro_map={})
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    assert macro_values(host) == {"{$FINE}": "yes"}
+
+
+def test_oversized_tag_value_is_dropped_not_sent(device_factory, run_sync, zabbix_host):
+    """Zabbix caps a tag value at 256 characters; the map has no such cap.
+
+    Same shape as the macro limit, and reachable the same way -- through
+    `comments`. The dropped tag must not cost the host its valid ones.
+    """
+    device = device_factory(address="10.0.0.80/24", comments="y" * 300)
+
+    run_sync(
+        device.name,
+        tag_sync=True,
+        tag_name=None,
+        device_tag_map={"comments": "toolong", "site/name": "site"},
+    )
+
+    host = zabbix_host(device.name)
+    assert host is not None, "an oversized tag value took the whole host down"
+    assert tag_pairs(host) == {("site", SITE_NAME.lower())}
+
+
+def test_unknown_tag_value_setting_falls_back_to_name(
+    device_factory, tag_factory, run_sync, zabbix_host
+):
+    """`tag_value` only accepts display/name/slug; anything else means name.
+
+    A quiet fallback (tags.py:129), so a typo'd `tag_value` produces a host that
+    looks synced and carries the wrong values. Pinned so the fallback is a
+    decision rather than an accident.
+    """
+    tag = tag_factory(name="Production")
+    device = device_factory(address="10.0.0.81/24", tags=[tag.id])
+
+    run_sync(device.name, tag_sync=True, tag_value="nonsense", device_tag_map={})
+
+    assert tag_pairs(zabbix_host(device.name)) == {("netbox", "production")}

--- a/tests/functional/test_host_attributes.py
+++ b/tests/functional/test_host_attributes.py
@@ -1,0 +1,445 @@
+"""Tags, usermacros and inventory, generated from NetBox and read back from Zabbix.
+
+The mocked suite already covers how ZabbixTags, ZabbixUsermacros and
+field_mapper build these structures. What it cannot cover is the half that only
+a real stack has an opinion about:
+
+- **Zabbix accepts what we build.** A tag, macro or inventory field that Zabbix
+  rejects fails the host.create call, and the mocked tests -- which assert on
+  the dict handed to a mock -- pass either way. Inventory is the sharp edge: a
+  key that is not one of Zabbix's ~70 inventory fields is an API error, so the
+  inventory maps are only really validated here.
+- **NetBox returns what the map asks for.** A map walks NetBox fields by name
+  (`device_type/model`); whether that path exists on the object NetBox actually
+  serves is not something a DummyNB can answer, because a DummyNB has whatever
+  fields its test gave it.
+
+So the assertions read the host back through the raw ZabbixAPI. Where a feature
+is a switch, the test pairs it with its off state -- an assertion that tags
+appear when tag_sync is on proves nothing unless something also proves they
+stay away when it is off.
+"""
+
+from tests.functional.bootstrap.seed_netbox import (
+    DEVICE_TYPE_MODEL,
+    MANUFACTURER_NAME,
+    ROLE_NAME,
+    SITE_NAME,
+)
+from tests.functional.conftest import macro_types, macro_values, tag_pairs
+
+# Zabbix inventory_mode as the API reports it (host.py:311-323).
+INVENTORY_DISABLED = "-1"
+INVENTORY_MANUAL = "0"
+INVENTORY_AUTOMATIC = "1"
+
+# Zabbix usermacro types (usermacros.py:57).
+MACRO_TEXT = "0"
+MACRO_SECRET = "1"
+
+
+# --- tags -------------------------------------------------------------------
+
+
+def test_tags_not_synced_when_disabled(
+    device_factory, tag_factory, run_sync, zabbix_host
+):
+    """tag_sync=False leaves the host untagged, whatever NetBox offers.
+
+    The off state for every tag test below. The device carries a NetBox tag and
+    a config context tag, so all three of ZabbixTags' sources have something to
+    contribute and the empty result is the flag's doing rather than an empty
+    device (host.py:591).
+    """
+    tag = tag_factory()
+    device = device_factory(
+        address="10.0.0.50/24",
+        tags=[tag.id],
+        config_context={"zabbix": {"tags": [{"env": "production"}]}},
+    )
+
+    run_sync(device.name)
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    assert host["tags"] == [], "tags were synced despite tag_sync=False"
+
+
+def test_tags_from_field_map(device_factory, run_sync, zabbix_host):
+    """A device_tag_map entry becomes a Zabbix tag, values lowercased.
+
+    `site/name` also exercises field_mapper's nested walk against a real
+    NetBox object: the sync gets the site as a *nested* record on the device,
+    and `name` is one of the few fields present there without extension.
+    """
+    device = device_factory(address="10.0.0.51/24")
+
+    run_sync(
+        device.name,
+        tag_sync=True,
+        tag_name=False,
+        device_tag_map={"site/name": "site", "role/name": "role"},
+    )
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    # tag_lower defaults to True, so the values arrive lowercased but the tag
+    # names -- which come from the map, not from NetBox -- are already lower.
+    assert ("site", SITE_NAME.lower()) in tag_pairs(host)
+    assert ("role", ROLE_NAME.lower()) in tag_pairs(host)
+
+
+def test_tag_lower_false_preserves_netbox_case(device_factory, run_sync, zabbix_host):
+    """tag_lower=False syncs NetBox's capitalisation through to Zabbix."""
+    device = device_factory(address="10.0.0.52/24")
+
+    run_sync(
+        device.name,
+        tag_sync=True,
+        tag_name=False,
+        tag_lower=False,
+        device_tag_map={"site/name": "Site"},
+    )
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    assert ("Site", SITE_NAME) in tag_pairs(host)
+
+
+def test_tags_from_config_context(device_factory, run_sync, zabbix_host):
+    """Tags listed under config_context['zabbix']['tags'] reach Zabbix.
+
+    The map and the NetBox-tag source are both off, so anything on the host
+    came from the config context.
+    """
+    device = device_factory(
+        address="10.0.0.53/24",
+        config_context={
+            "zabbix": {"tags": [{"env": "Production"}, {"team": "Networking"}]}
+        },
+    )
+
+    run_sync(device.name, tag_sync=True, tag_name=False, device_tag_map={})
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    assert tag_pairs(host) == {("env", "production"), ("team", "networking")}
+
+
+def test_netbox_tags_synced_under_tag_name(
+    device_factory, tag_factory, run_sync, zabbix_host
+):
+    """NetBox tags have no key/value shape, so they land under `tag_name`.
+
+    Two NetBox tags become two Zabbix tags sharing one name -- which Zabbix
+    permits, and which is the whole reason tag_name exists.
+    """
+    first = tag_factory(name="Rack-A")
+    second = tag_factory(name="Rack-B")
+    device = device_factory(address="10.0.0.54/24", tags=[first.id, second.id])
+
+    run_sync(
+        device.name,
+        tag_sync=True,
+        tag_name="NetBox",
+        tag_value="name",
+        device_tag_map={},
+    )
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    assert tag_pairs(host) == {("netbox", "rack-a"), ("netbox", "rack-b")}
+
+
+def test_netbox_tag_value_uses_slug(device_factory, tag_factory, run_sync, zabbix_host):
+    """tag_value='slug' picks the slug rather than the name.
+
+    The tag's name and slug differ, so a sync that ignored tag_value would
+    still produce a tag -- just the wrong one.
+    """
+    tag = tag_factory(name="Production Site")
+    assert tag.slug != tag.name, "fixture must make name and slug distinguishable"
+    device = device_factory(address="10.0.0.55/24", tags=[tag.id])
+
+    run_sync(
+        device.name,
+        tag_sync=True,
+        tag_name="NetBox",
+        tag_value="slug",
+        device_tag_map={},
+    )
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    assert tag_pairs(host) == {("netbox", tag.slug.lower())}
+
+
+def test_tags_updated_on_rerun(device_factory, run_sync, zabbix_host):
+    """A tag removed in NetBox is removed from the Zabbix host on the next run.
+
+    Tags are replaced wholesale rather than merged, so a stale tag would
+    otherwise outlive the config context entry that created it. The device is
+    edited between syncs, which is what a user changing a config context does.
+    """
+    device = device_factory(
+        address="10.0.0.56/24",
+        config_context={"zabbix": {"tags": [{"env": "staging"}]}},
+    )
+
+    run_sync(device.name, tag_sync=True, tag_name=False, device_tag_map={})
+    assert tag_pairs(zabbix_host(device.name)) == {("env", "staging")}
+
+    device.local_context_data = {"zabbix": {"tags": [{"env": "production"}]}}
+    device.save()
+
+    run_sync(device.name, tag_sync=True, tag_name=False, device_tag_map={})
+
+    host = zabbix_host(device.name)
+    assert tag_pairs(host) == {("env", "production")}, "stale tag survived the rerun"
+
+
+# --- usermacros -------------------------------------------------------------
+
+
+def test_usermacros_not_synced_when_disabled(device_factory, run_sync, zabbix_host):
+    """usermacro_sync=False leaves the host without macros (host.py:570)."""
+    device = device_factory(
+        address="10.0.0.60/24",
+        config_context={"zabbix": {"usermacros": {"{$SNMP_COMMUNITY}": "public"}}},
+    )
+
+    run_sync(device.name)
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    assert host["macros"] == [], "macros were synced despite usermacro_sync=False"
+
+
+def test_usermacros_from_field_map(device_factory, run_sync, zabbix_host):
+    """A device_usermacro_map entry becomes a Zabbix usermacro.
+
+    `id` is in the map to pin down field_mapper's handling of a non-string
+    NetBox value: Zabbix's macro value is a string, so the int must be
+    converted rather than sent as-is and rejected.
+    """
+    device = device_factory(address="10.0.0.61/24", serial="SN-12345")
+
+    run_sync(
+        device.name,
+        usermacro_sync=True,
+        device_usermacro_map={"serial": "{$HW_SERIAL}", "id": "{$NB_ID}"},
+    )
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    macros = macro_values(host)
+    assert macros["{$HW_SERIAL}"] == "SN-12345"
+    assert macros["{$NB_ID}"] == str(device.id)
+
+
+def test_usermacros_from_config_context(device_factory, run_sync, zabbix_host):
+    """Config context macros sync in both their string and dict forms.
+
+    The dict form is the one that carries a type and description; the plain
+    string form is shorthand for a text macro (usermacros.py:88).
+    """
+    device = device_factory(
+        address="10.0.0.62/24",
+        config_context={
+            "zabbix": {
+                "usermacros": {
+                    "{$SNMP_COMMUNITY}": "public",
+                    "{$IFCONTROL}": {
+                        "value": "1",
+                        "type": "text",
+                        "description": "Interface control",
+                    },
+                }
+            }
+        },
+    )
+
+    run_sync(device.name, usermacro_sync=True, device_usermacro_map={})
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    assert macro_values(host) == {"{$SNMP_COMMUNITY}": "public", "{$IFCONTROL}": "1"}
+    assert macro_types(host)["{$IFCONTROL}"] == MACRO_TEXT
+
+
+def test_secret_usermacro_created_as_secret(device_factory, run_sync, zabbix_host):
+    """A macro typed `secret` is created with Zabbix's secret type.
+
+    The type is most of what can be asserted: Zabbix withholds a secret macro's
+    value, omitting the key from the response rather than blanking it. It is
+    also the part that matters -- the same value stored as a text macro would
+    be readable by anyone with API access.
+    """
+    device = device_factory(
+        address="10.0.0.63/24",
+        config_context={
+            "zabbix": {
+                "usermacros": {
+                    "{$SECRET_PASS}": {"value": "hunter2", "type": "secret"},
+                    "{$PLAIN}": {"value": "visible", "type": "text"},
+                }
+            }
+        },
+    )
+
+    run_sync(device.name, usermacro_sync=True, device_usermacro_map={})
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    assert macro_types(host)["{$SECRET_PASS}"] == MACRO_SECRET
+    assert macro_types(host)["{$PLAIN}"] == MACRO_TEXT
+    assert macro_values(host)["{$SECRET_PASS}"] is None, (
+        "Zabbix returned a secret macro's value; it should be withheld"
+    )
+    assert macro_values(host)["{$PLAIN}"] == "visible"
+
+
+def test_invalid_macro_name_skipped_without_failing_host(
+    device_factory, run_sync, zabbix_host
+):
+    """One unusable macro does not cost the host its valid ones.
+
+    `NOT_A_MACRO` fails validate_macro. Zabbix would reject the whole
+    host.create if it were sent, so this proves the macro is dropped before the
+    call rather than merely logged.
+    """
+    device = device_factory(
+        address="10.0.0.64/24",
+        config_context={
+            "zabbix": {"usermacros": {"NOT_A_MACRO": "nope", "{$VALID}": "yes"}}
+        },
+    )
+
+    run_sync(device.name, usermacro_sync=True, device_usermacro_map={})
+
+    host = zabbix_host(device.name)
+    assert host is not None, "invalid macro took the whole host down"
+    assert macro_values(host) == {"{$VALID}": "yes"}
+
+
+# --- inventory --------------------------------------------------------------
+
+
+def test_inventory_not_synced_when_mode_disabled(device_factory, run_sync, zabbix_host):
+    """inventory_mode='disabled' wins even with inventory_sync=True.
+
+    The combination is a misconfiguration the sync logs and declines to act on
+    (host.py:312-319), so the host must come out with inventory off rather than
+    populated.
+    """
+    device = device_factory(address="10.0.0.70/24", serial="SN-DISABLED")
+
+    run_sync(device.name, inventory_sync=True, inventory_mode="disabled")
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    assert host["inventory_mode"] == INVENTORY_DISABLED
+    assert host["inventory"] in ([], {}), "inventory populated despite disabled mode"
+
+
+def test_inventory_synced_in_manual_mode(device_factory, run_sync, zabbix_host):
+    """The default device_inventory_map populates Zabbix inventory.
+
+    Left as the default map on purpose: every key in it is asserted by Zabbix
+    to be a real inventory field, so this is what catches a typo'd or renamed
+    field there -- the mocked tests would accept `serialno_typo` happily.
+    """
+    device = device_factory(
+        address="10.0.0.71/24", serial="SN-MANUAL", asset_tag="ASSET-001"
+    )
+
+    run_sync(device.name, inventory_sync=True, inventory_mode="manual")
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    assert host["inventory_mode"] == INVENTORY_MANUAL
+
+    inventory = host["inventory"]
+    assert inventory["serialno_a"] == "SN-MANUAL"
+    assert inventory["asset_tag"] == "ASSET-001"
+    assert inventory["name"] == device.name
+    assert inventory["type"] == DEVICE_TYPE_MODEL
+    assert inventory["vendor"] == MANUFACTURER_NAME
+
+
+def test_inventory_automatic_mode(device_factory, run_sync, zabbix_host):
+    """inventory_mode='automatic' maps to Zabbix's automatic mode."""
+    device = device_factory(address="10.0.0.72/24", serial="SN-AUTO")
+
+    run_sync(device.name, inventory_sync=True, inventory_mode="automatic")
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    assert host["inventory_mode"] == INVENTORY_AUTOMATIC
+    assert host["inventory"]["serialno_a"] == "SN-AUTO"
+
+
+def test_inventory_mode_set_without_sync(device_factory, run_sync, zabbix_host):
+    """inventory_mode alone sets the mode and syncs no fields.
+
+    The two settings are independent: a user may want Zabbix's own discovery to
+    fill the inventory while NetBox stays out of it.
+    """
+    device = device_factory(address="10.0.0.73/24", serial="SN-NOSYNC")
+
+    run_sync(device.name, inventory_sync=False, inventory_mode="manual")
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    assert host["inventory_mode"] == INVENTORY_MANUAL
+    assert "SN-NOSYNC" not in str(host["inventory"]), (
+        "NetBox data reached the inventory despite inventory_sync=False"
+    )
+
+
+def test_inventory_maps_custom_field(
+    device_factory, custom_field_factory, run_sync, zabbix_host
+):
+    """A custom field can be mapped into inventory through a nested path.
+
+    `custom_fields/<name>` is the documented way to get user-defined NetBox
+    data into Zabbix, and it is the deepest walk field_mapper does against a
+    real object.
+    """
+    cf = custom_field_factory(object_types=["dcim.device"])
+    device = device_factory(address="10.0.0.74/24")
+    device.custom_fields[cf] = "Rack 42"
+    device.save()
+
+    run_sync(
+        device.name,
+        inventory_sync=True,
+        inventory_mode="manual",
+        device_inventory_map={f"custom_fields/{cf}": "alias", "name": "name"},
+    )
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    assert host["inventory"]["alias"] == "Rack 42"
+
+
+def test_empty_netbox_field_becomes_empty_inventory_value(
+    device_factory, run_sync, zabbix_host
+):
+    """A NetBox field with no value maps to "", not to None.
+
+    Zabbix rejects a null inventory value, so field_mapper's empty-string
+    fallback is what keeps a device with a blank serial syncable at all.
+    """
+    device = device_factory(address="10.0.0.75/24", serial="")
+
+    run_sync(
+        device.name,
+        inventory_sync=True,
+        inventory_mode="manual",
+        device_inventory_map={"serial": "serialno_a", "name": "name"},
+    )
+
+    host = zabbix_host(device.name)
+    assert host is not None, "a device with an empty serial failed to sync"
+    assert host["inventory"]["serialno_a"] == ""

--- a/tests/functional/test_hostgroups.py
+++ b/tests/functional/test_hostgroups.py
@@ -1,0 +1,222 @@
+"""Hostgroup generation, against real NetBox regions, site groups and CFs.
+
+The hostgroup is the most visible mapping the sync produces -- it is where every
+host lands in Zabbix -- and the only functional coverage of it so far is the
+default `site/manufacturer/role` in test_device_sync. The parts a mock cannot
+vouch for are the ones that read NetBox's own tree shapes:
+
+- **Nested regions and site groups** are walked with `build_path` (tools.py:24),
+  which reconstructs the ancestry from a flat recordset using each record's
+  `_depth` and `parent` -- fields only a real NetBox populates, and it matches
+  ancestors by their *name*.
+- **A format segment that is not a built-in option** is looked up as a custom
+  field on the host (hostgroups.py:157), or used as a literal if quoted. Whether
+  a given custom field is even visible on the object is a NetBox question.
+
+The `traverse_*` flags are switches, so each is paired with its off state: a
+flat region name when off, the full path when on.
+"""
+
+import contextlib
+from uuid import uuid4
+
+import pynetbox
+import pytest
+
+from tests.functional.bootstrap import seed_netbox
+
+pytestmark = pytest.mark.functional
+
+ROLE = seed_netbox.ROLE_NAME
+
+
+@pytest.fixture
+def topology(nb):
+    """Build region / site-group trees and sites, and tear them down in order.
+
+    Everything created here outlives the per-test device that sits in it, so
+    this fixture must be requested *before* device_factory in a test's
+    signature: fixtures finalize in reverse setup order, so device_factory then
+    finalizes first and removes the device before its site is deleted. Within
+    this teardown, reversed creation order deletes children before parents and
+    sites before the regions they reference.
+    """
+    created = []
+
+    class Topology:
+        def region(self, name: str | None = None, parent=None):
+            suffix = uuid4().hex[:8]
+            region = nb.dcim.regions.create(
+                name=name or f"reg-{suffix}",
+                slug=f"reg-{suffix}",
+                parent=parent.id if parent else None,
+            )
+            created.append(region)
+            return region
+
+        def site_group(self, name: str | None = None, parent=None):
+            suffix = uuid4().hex[:8]
+            group = nb.dcim.site_groups.create(
+                name=name or f"sg-{suffix}",
+                slug=f"sg-{suffix}",
+                parent=parent.id if parent else None,
+            )
+            created.append(group)
+            return group
+
+        def site(self, region=None, group=None):
+            suffix = uuid4().hex[:8]
+            site = nb.dcim.sites.create(
+                name=f"site-{suffix}",
+                slug=f"site-{suffix}",
+                status="active",
+                region=region.id if region else None,
+                group=group.id if group else None,
+            )
+            created.append(site)
+            return site
+
+    yield Topology()
+
+    for obj in reversed(created):
+        with contextlib.suppress(pynetbox.RequestError):
+            obj.delete()
+
+
+def hostgroup_of(host: dict) -> str:
+    """The single hostgroup name the sync built for a host."""
+    groups = [group["name"] for group in host["hostgroups"]]
+    assert len(groups) == 1, f"expected exactly one hostgroup, got {groups}"
+    return groups[0]
+
+
+def test_region_is_flat_by_default(topology, device_factory, run_sync, zabbix_host):
+    """Without traverse_regions, only the site's own region name is used.
+
+    The off state of the switch below. `str(site.region)` is the child region's
+    name alone -- NetBox does not fold the ancestry into it -- so the parent
+    must be absent here, not merely un-nested.
+    """
+    parent = topology.region(name=f"EU-{uuid4().hex[:6]}")
+    child = topology.region(name=f"NL-{uuid4().hex[:6]}", parent=parent)
+    device = device_factory(site=topology.site(region=child).id)
+
+    run_sync(device.name, hostgroup_format="region/role", traverse_regions=False)
+
+    assert hostgroup_of(zabbix_host(device.name)) == f"{child.name}/{ROLE}"
+
+
+def test_nested_regions_traversed_when_enabled(
+    topology, device_factory, run_sync, zabbix_host
+):
+    """traverse_regions folds the whole ancestry into the hostgroup path."""
+    eu = topology.region(name=f"EU-{uuid4().hex[:6]}")
+    nl = topology.region(name=f"NL-{uuid4().hex[:6]}", parent=eu)
+    ams = topology.region(name=f"AMS-{uuid4().hex[:6]}", parent=nl)
+    device = device_factory(site=topology.site(region=ams).id)
+
+    run_sync(device.name, hostgroup_format="region/role", traverse_regions=True)
+
+    assert hostgroup_of(zabbix_host(device.name)) == (
+        f"{eu.name}/{nl.name}/{ams.name}/{ROLE}"
+    )
+
+
+def test_nested_site_groups_traversed_when_enabled(
+    topology, device_factory, run_sync, zabbix_host
+):
+    """The same walk over the site-group tree rather than the region tree.
+
+    Worth its own test because it is a second caller of `build_path` reading a
+    different NetBox endpoint -- a change to how NetBox serialises site groups
+    would break this while leaving the region test green.
+    """
+    parent = topology.site_group(name=f"PG-{uuid4().hex[:6]}")
+    child = topology.site_group(name=f"CG-{uuid4().hex[:6]}", parent=parent)
+    device = device_factory(site=topology.site(group=child).id)
+
+    run_sync(device.name, hostgroup_format="site_group/role", traverse_site_groups=True)
+
+    assert hostgroup_of(zabbix_host(device.name)) == (
+        f"{parent.name}/{child.name}/{ROLE}"
+    )
+
+
+def test_literal_segment_is_used_verbatim(device_factory, run_sync, zabbix_host):
+    """A quoted segment is a literal, not looked up (hostgroups.py:149)."""
+    device = device_factory()
+
+    run_sync(device.name, hostgroup_format="'Datacenter'/site/role")
+
+    assert hostgroup_of(zabbix_host(device.name)) == (
+        f"Datacenter/{seed_netbox.SITE_NAME}/{ROLE}"
+    )
+
+
+def test_custom_field_segment_resolved_from_the_device(
+    device_factory, custom_field_factory, run_sync, zabbix_host
+):
+    """An unknown segment is resolved as a custom field on the host.
+
+    This is how a site- or tenant-specific grouping that NetBox models as a
+    custom field reaches Zabbix. The field has to actually exist and be
+    populated on the device, which is why this can only be shown against a real
+    NetBox.
+    """
+    cf = custom_field_factory(object_types=["dcim.device"])
+    device = device_factory()
+    device.custom_fields[cf] = "Zone-A"
+    device.save()
+
+    run_sync(device.name, hostgroup_format=f"site/{cf}/role")
+
+    assert hostgroup_of(zabbix_host(device.name)) == (
+        f"{seed_netbox.SITE_NAME}/Zone-A/{ROLE}"
+    )
+
+
+def test_empty_segment_is_skipped(device_factory, run_sync, zabbix_host):
+    """A format field with no value drops out rather than leaving a blank.
+
+    The device has no location, so `location` contributes nothing and the
+    hostgroup is built from the segments that do. A `//` in a Zabbix hostgroup
+    name would be a real, and confusing, group -- so the drop matters.
+    """
+    device = device_factory()
+
+    run_sync(device.name, hostgroup_format="site/location/role")
+
+    assert hostgroup_of(zabbix_host(device.name)) == (f"{seed_netbox.SITE_NAME}/{ROLE}")
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "build_path matches ancestors by name (tools.py:37), but NetBox only "
+        "enforces unique region names at the top level -- a name repeated under "
+        "two different parents is allowed. build_path then finds two matches, "
+        "cannot choose, and returns [] (tools.py:32,35), so the entire region "
+        "path is silently dropped and the device lands in the wrong hostgroup "
+        "with no error. Remove this marker once build_path disambiguates by "
+        "parent/id rather than name."
+    ),
+)
+def test_ambiguous_region_name_still_traverses(
+    topology, device_factory, run_sync, zabbix_host
+):
+    """A region name reused under two parents must not lose the path.
+
+    The device's region is unambiguous *in context* -- it has one parent -- but
+    build_path only has the name to go on. The correct hostgroup is the full
+    ancestry; today the sync produces just the role.
+    """
+    eu = topology.region(name=f"EU-{uuid4().hex[:6]}")
+    us = topology.region(name=f"US-{uuid4().hex[:6]}")
+    shared = f"North-{uuid4().hex[:6]}"
+    north_eu = topology.region(name=shared, parent=eu)
+    topology.region(name=shared, parent=us)
+    device = device_factory(site=topology.site(region=north_eu).id)
+
+    run_sync(device.name, hostgroup_format="region/role", traverse_regions=True)
+
+    assert hostgroup_of(zabbix_host(device.name)) == (f"{eu.name}/{shared}/{ROLE}")

--- a/tests/functional/test_interfaces.py
+++ b/tests/functional/test_interfaces.py
@@ -1,0 +1,282 @@
+"""Which address a Zabbix interface gets, and how many interfaces there are.
+
+Two settings decide this and neither is exercised elsewhere:
+
+- `preferred_ip` picks between a device's v4 and v6 primary. Its three values
+  are not symmetric -- "auto" defers to NetBox's own choice, while "ipv4" and
+  "ipv6" are preferences with a fallback, not requirements. A dual-stack device
+  is the only thing that tells the three apart, so every test here uses one.
+- `oob_sync` adds a second Zabbix interface built from the device's OOB IP.
+
+The interface count is asserted as well as its contents. A second interface
+that silently fails to appear looks identical to a first interface that is
+correct, so `len(host["interfaces"])` is what separates them.
+"""
+
+import pytest
+
+from tests.functional.conftest import strip_ip_mask
+
+pytestmark = pytest.mark.functional
+
+SNMP_INTERFACE_TYPE = "2"
+AGENT_INTERFACE_TYPE = "1"
+IPMI_INTERFACE_TYPE = "3"
+
+# Named so the interface-count assertions read as intent rather than as a
+# magic number: "the main one and the OOB one", not "two of something".
+MAIN_AND_OOB = 2
+
+V4 = "10.44.0.1/24"
+V6 = "2001:db8:44::1/64"
+
+# An OOB interface has to differ in *type* from the main one or the host is
+# rejected outright; see test_oob_sync_needs_a_distinct_interface_type.
+OOB_AGENT_CONTEXT = {"zabbix": {"oob_interface_type": 1}}
+
+
+def interface_ips(host: dict) -> set[str]:
+    return {interface["ip"] for interface in host["interfaces"]}
+
+
+def interface_by_type(host: dict, int_type: str) -> dict:
+    matches = [i for i in host["interfaces"] if i["type"] == int_type]
+    assert len(matches) == 1, f"expected one type-{int_type} interface, got {matches}"
+    return matches[0]
+
+
+def test_auto_defers_to_the_netbox_primary(device_factory, run_sync, zabbix_host):
+    """ "auto" reads `nb.primary_ip`, which NetBox resolves to v6 when both exist.
+
+    This is the default, and the behaviour most likely to surprise: setting a v6
+    primary in NetBox silently moves an existing Zabbix interface off its v4
+    address. Pinned so that stops being silent if it ever changes.
+    """
+    device = device_factory(address=V4, address6=V6)
+
+    run_sync(device.name)
+
+    interface = zabbix_host(device.name)["interfaces"][0]
+    assert interface["ip"] == strip_ip_mask(V6)
+
+
+def test_ipv4_preference_wins_over_the_netbox_primary(
+    device_factory, run_sync, zabbix_host
+):
+    """The same device as above, with the setting changed and nothing else.
+
+    Paired with the test above deliberately: identical NetBox state, different
+    result, so the assertion can only be explained by the setting being read.
+    """
+    device = device_factory(address=V4, address6=V6)
+
+    run_sync(device.name, preferred_ip="ipv4")
+
+    assert zabbix_host(device.name)["interfaces"][0]["ip"] == strip_ip_mask(V4)
+
+
+def test_ipv6_preference_selects_the_v6_address(device_factory, run_sync, zabbix_host):
+    device = device_factory(address=V4, address6=V6)
+
+    run_sync(device.name, preferred_ip="ipv6")
+
+    assert zabbix_host(device.name)["interfaces"][0]["ip"] == strip_ip_mask(V6)
+
+
+@pytest.mark.parametrize("preference", ["ipv4", "ipv6"])
+def test_a_preference_falls_back_rather_than_failing(
+    preference, device_factory, run_sync, zabbix_host
+):
+    """Neither setting is a requirement: a single-stack device still syncs.
+
+    `preferred_ip` is a preference with an `or` behind it (host.py:169-172), so
+    a v6-preferring config pointed at a v4-only estate must not drop every host.
+    Both directions are parametrised because only one of them is the code path a
+    given reader expects to be safe.
+    """
+    device = device_factory(address=V4)
+
+    run_sync(device.name, preferred_ip=preference)
+
+    host = zabbix_host(device.name)
+    assert host is not None, f"preferred_ip={preference} dropped a v4-only device"
+    assert host["interfaces"][0]["ip"] == strip_ip_mask(V4)
+
+
+def test_oob_interface_absent_by_default(device_factory, run_sync, zabbix_host):
+    """The off state: an OOB IP on the device changes nothing while oob_sync is off.
+
+    The device carries a usable OOB IP and a context that would make the second
+    interface valid, so the only reason for it not to appear is the setting.
+    """
+    device = device_factory(
+        oob_address="10.44.9.1/24", config_context=OOB_AGENT_CONTEXT
+    )
+
+    run_sync(device.name)
+
+    assert len(zabbix_host(device.name)["interfaces"]) == 1
+
+
+def test_oob_sync_adds_a_second_interface(device_factory, run_sync, zabbix_host):
+    """On, with the distinct type it requires: two interfaces, two addresses.
+
+    Both are asserted by type rather than by list position -- Zabbix does not
+    promise an order, and asserting `interfaces[1]` would make this test fail
+    for a reason that has nothing to do with the setting.
+    """
+    oob = "10.44.9.2/24"
+    device = device_factory(
+        address=V4, oob_address=oob, config_context=OOB_AGENT_CONTEXT
+    )
+
+    run_sync(device.name, oob_sync=True)
+
+    host = zabbix_host(device.name)
+    assert len(host["interfaces"]) == MAIN_AND_OOB
+    assert interface_by_type(host, SNMP_INTERFACE_TYPE)["ip"] == strip_ip_mask(V4)
+    assert interface_by_type(host, AGENT_INTERFACE_TYPE)["ip"] == strip_ip_mask(oob)
+    assert interface_ips(host) == {strip_ip_mask(V4), strip_ip_mask(oob)}
+
+
+def test_oob_sync_needs_a_distinct_interface_type(
+    device_factory, run_sync, zabbix_host
+):
+    """Enabling oob_sync without an `oob_interface_type` costs the host entirely.
+
+    Both interfaces fall back to `set_default_snmp` (host.py:496), so both are
+    type 2; `_verify_interfaces` rejects duplicate types (host.py:458) and the
+    host raises `SyncInventoryError`. That is the documented behaviour rather
+    than a bug -- Zabbix cannot hold two main interfaces of one type -- but it
+    is a sharp edge: turning on one boolean drops every device with an OOB IP
+    until a config context is added too.
+
+    Asserting the host is absent rather than the exception: the run continues,
+    and the observable cost is the missing host.
+    """
+    device = device_factory(oob_address="10.44.9.3/24")
+
+    run_sync(device.name, oob_sync=True)
+
+    assert zabbix_host(device.name) is None
+
+
+def test_oob_sync_is_inert_for_a_device_with_no_oob_ip(
+    device_factory, run_sync, zabbix_host
+):
+    """The guard in host.py:690 -- a device without an OOB IP is untouched.
+
+    Necessary because the setting is global while OOB IPs are per device: if
+    this were not inert, enabling oob_sync would break every device that has no
+    OOB IP, which is most of them.
+    """
+    device = device_factory(address=V4)
+
+    run_sync(device.name, oob_sync=True)
+
+    host = zabbix_host(device.name)
+    assert host is not None
+    assert len(host["interfaces"]) == 1
+    assert host["interfaces"][0]["ip"] == strip_ip_mask(V4)
+
+
+def test_oob_interface_port_comes_from_config_context(
+    device_factory, run_sync, zabbix_host
+):
+    """`oob_interface_port` is read separately from `interface_port`.
+
+    The two share their code path and differ only by key prefix
+    (interface.py:39-41), which is exactly the kind of thing that works in one
+    direction and not the other. Both are set here, to different values, so a
+    swap is visible.
+
+    The `snmp` block is required rather than decorative: naming `interface_type`
+    2 explicitly routes through `set_snmp`, which raises unless the context
+    carries SNMP parameters (interface.py:120). Leaving the type unset would
+    have fallen back to `set_default_snmp` and needed nothing -- so being
+    explicit about the type is what makes the details mandatory.
+    """
+    device = device_factory(
+        oob_address="10.44.9.4/24",
+        config_context={
+            "zabbix": {
+                "interface_type": 2,
+                "interface_port": 1161,
+                "snmp": {"version": 2},
+                "oob_interface_type": 1,
+                "oob_interface_port": 1050,
+            }
+        },
+    )
+
+    run_sync(device.name, oob_sync=True)
+
+    host = zabbix_host(device.name)
+    assert interface_by_type(host, SNMP_INTERFACE_TYPE)["port"] == "1161"
+    assert interface_by_type(host, AGENT_INTERFACE_TYPE)["port"] == "1050"
+
+
+def test_oob_interface_can_be_ipmi(device_factory, run_sync, zabbix_host):
+    """The realistic OOB case, and the one the feature exists for.
+
+    A BMC is reached over IPMI, so type 3 on the OOB interface with SNMP on the
+    main one is the shape a real user configures. Worth its own test because
+    IPMI takes a different branch in `set_interface_details` (host.py:493) than
+    the agent type used above.
+
+    Note the `ipmi` block carries no `oob_` prefix. Type and port are read from
+    OOB-specific keys, but the credentials block is not: `set_ipmi` reads
+    `context["zabbix"]["ipmi"]` regardless of which interface it is building
+    (interface.py:134). So a device whose main interface is also IPMI cannot
+    give the two different credentials.
+    """
+    oob = "10.44.9.5/24"
+    device = device_factory(
+        address=V4,
+        oob_address=oob,
+        config_context={
+            "zabbix": {
+                "oob_interface_type": 3,
+                "ipmi": {"username": "bmc-user", "password": "bmc-pass"},
+            }
+        },
+    )
+
+    run_sync(device.name, oob_sync=True)
+
+    host = zabbix_host(device.name)
+    assert len(host["interfaces"]) == MAIN_AND_OOB
+    assert interface_by_type(host, IPMI_INTERFACE_TYPE)["ip"] == strip_ip_mask(oob)
+    assert interface_by_type(host, IPMI_INTERFACE_TYPE)["port"] == "623"
+
+
+def test_turning_oob_sync_off_does_not_remove_an_in_use_interface(
+    device_factory, run_sync, zabbix_host
+):
+    """Disabling the setting is attempted but Zabbix refuses, and that is survivable.
+
+    `consistency_check` does try to delete the now-unwanted interface, but
+    Zabbix rejects the call for any interface an item is bound to -- here the
+    template's "ICMP ping", which Zabbix attached to the agent interface the
+    moment it appeared. The sync logs the rejection (host.py:1235) and carries
+    on rather than failing the host.
+
+    So the setting is effectively one-way for a host that has already synced:
+    turning `oob_sync` off leaves the extra interface in place. Asserted as
+    current behaviour rather than as a bug -- the alternative is for the sync
+    to move or delete Zabbix items it did not create -- but it is worth pinning,
+    because "the interface is still there" is otherwise indistinguishable from
+    the setting having been ignored entirely.
+    """
+    device = device_factory(
+        address=V4, oob_address="10.44.9.6/24", config_context=OOB_AGENT_CONTEXT
+    )
+    run_sync(device.name, oob_sync=True)
+    assert len(zabbix_host(device.name)["interfaces"]) == MAIN_AND_OOB
+
+    run_sync(device.name, oob_sync=False)
+
+    host = zabbix_host(device.name)
+    assert len(host["interfaces"]) == MAIN_AND_OOB, "Zabbix started allowing the delete"
+    # The host itself is intact: the failed delete cost nothing else.
+    assert interface_by_type(host, SNMP_INTERFACE_TYPE)["ip"] == strip_ip_mask(V4)

--- a/tests/functional/test_netbox_filters.py
+++ b/tests/functional/test_netbox_filters.py
@@ -284,3 +284,47 @@ def test_vm_filter_reaches_netbox_when_vm_sync_enabled(sync_runner, netbox_reque
     ]
     assert ["dcim.device"] in object_types
     assert ["virtualization.virtualmachine"] in object_types
+
+
+def test_vm_config_filter_scopes_the_sync(vm_factory, sync_runner, zabbix_host, seeded):
+    """`nb_vm_filter` alone, with no method filter, decides which VMs sync.
+
+    The test above proves the filter reaches the wire; this one proves it
+    *filtered*, which is the distinction this whole file exists for. A decoy VM
+    is seeded that the filter must exclude -- without it, a sync that ignored
+    the filter entirely would look identical.
+    """
+    target = vm_factory()
+    decoy = vm_factory()
+
+    sync_runner(
+        device_filter={"name": NO_DEVICE},
+        sync_vms=True,
+        nb_vm_filter={"name": target.name},
+    )
+
+    assert zabbix_host(target.name) is not None, "the filtered VM did not sync"
+    assert zabbix_host(decoy.name) is None, "nb_vm_filter did not exclude the decoy"
+
+
+def test_method_vm_filter_overrides_the_config_vm_filter(
+    vm_factory, sync_runner, zabbix_host
+):
+    """On an overlapping key the method filter wins, as it does for devices.
+
+    The VM half of `_combine_filters` is a separate call site from the device
+    half, so the precedence has to be checked on both -- the same reason the
+    VM maps get their own tests rather than being assumed to match.
+    """
+    target = vm_factory()
+    other = vm_factory()
+
+    sync_runner(
+        device_filter={"name": NO_DEVICE},
+        vm_filter={"name": target.name},
+        sync_vms=True,
+        nb_vm_filter={"name": other.name},
+    )
+
+    assert zabbix_host(target.name) is not None, "method VM filter did not win"
+    assert zabbix_host(other.name) is None, "config VM filter was not overridden"

--- a/tests/functional/test_proxies.py
+++ b/tests/functional/test_proxies.py
@@ -1,0 +1,368 @@
+"""Assigning a Zabbix proxy or proxy group, and the four settings behind it.
+
+A proxy is named in NetBox and resolved against Zabbix by name, and the name can
+come from three places with a defined precedence:
+
+1. a device custom field, if `proxy_cf` / `proxy_group_cf` names one,
+2. that same custom field on the device's *site*, as a per-site default,
+3. the device's config context.
+
+On top of that, a proxy group beats a plain proxy on Zabbix 7+, and
+`full_proxy_sync` decides whether a proxy set in Zabbix but absent from NetBox
+is removed or left alone. That last one is the dangerous setting -- it is the
+only one here that deletes configuration -- so both its states are tested.
+
+Every test resolves against a proxy that really exists in Zabbix. Asserting
+that the sync sent a name would prove nothing: the whole feature is the lookup.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+pytestmark = pytest.mark.functional
+
+# host.monitored_by: 0 = server, 1 = proxy, 2 = proxy group.
+MONITORED_BY_SERVER = "0"
+MONITORED_BY_PROXY = "1"
+MONITORED_BY_PROXY_GROUP = "2"
+
+
+@pytest.fixture
+def proxy_factory(zapi):
+    """Create Zabbix proxies and proxy groups, and remove them afterwards.
+
+    Request this fixture *before* `device_factory` in a test signature. Zabbix
+    refuses to delete a proxy while a host still points at it, and finalizers
+    run in reverse setup order, so first here means the proxies go last.
+    """
+    proxies = []
+    groups = []
+
+    def proxy(name: str | None = None) -> str:
+        name = name or f"fn-proxy-{uuid4().hex[:8]}"
+        # operating_mode 0 is an active proxy, which needs no address or port:
+        # nothing ever connects to it, and the sync only reads its name.
+        proxies.append(zapi.proxy.create(name=name, operating_mode=0)["proxyids"][0])
+        return name
+
+    def group(name: str | None = None) -> str:
+        name = name or f"fn-pgroup-{uuid4().hex[:8]}"
+        groups.append(
+            zapi.proxygroup.create(name=name, failover_delay="10s", min_online="1")[
+                "proxy_groupids"
+            ][0]
+        )
+        return name
+
+    proxy.group = group
+    yield proxy
+
+    for proxyid in proxies:
+        zapi.proxy.delete(proxyid)
+    for groupid in groups:
+        zapi.proxygroup.delete(groupid)
+
+
+@pytest.fixture
+def proxy_id(zapi):
+    """Resolve a proxy name to its Zabbix id, for comparing against a host."""
+
+    def _get(name: str) -> str:
+        found = zapi.proxy.get(filter={"name": name}, output=["proxyid"])
+        assert found, f"no Zabbix proxy named {name}"
+        return found[0]["proxyid"]
+
+    return _get
+
+
+def proxy_assignment(host: dict) -> tuple[str, str]:
+    """The two fields that together say what is monitoring a host.
+
+    Returned as a pair because neither means anything alone: `proxyid` is "0"
+    both when no proxy is set and when a proxy *group* is, so a test asserting
+    only on it cannot tell those apart.
+    """
+    return host["monitored_by"], host.get("proxyid", "0")
+
+
+def test_proxy_from_config_context(
+    proxy_factory, device_factory, run_sync, zabbix_host, zapi
+):
+    """The baseline: a proxy named in the config context is looked up and set."""
+    proxy_name = proxy_factory()
+    device = device_factory(config_context={"zabbix": {"proxy": proxy_name}})
+
+    run_sync(device.name)
+
+    monitored_by, proxyid = proxy_assignment(zabbix_host(device.name))
+    assert monitored_by == MONITORED_BY_PROXY
+    expected = zapi.proxy.get(filter={"name": proxy_name}, output=["proxyid"])
+    assert proxyid == expected[0]["proxyid"]
+
+
+def test_no_proxy_leaves_the_host_on_the_server(device_factory, run_sync, zabbix_host):
+    """The off state, and the default: nothing named means nothing assigned."""
+    device = device_factory()
+
+    run_sync(device.name)
+
+    assert proxy_assignment(zabbix_host(device.name)) == (MONITORED_BY_SERVER, "0")
+
+
+def test_proxy_from_a_device_custom_field(
+    proxy_factory, custom_field_factory, device_factory, run_sync, zabbix_host
+):
+    """`proxy_cf` names a custom field, and the field's value names the proxy.
+
+    The setting is off by default (`proxy_cf: False`), so the custom field is
+    inert until the config points at it -- which is why this test sets both and
+    the test below sets only the field.
+    """
+    proxy_name = proxy_factory()
+    cf_name = custom_field_factory(["dcim.device"])
+    device = device_factory()
+    device.custom_fields[cf_name] = proxy_name
+    device.save()
+
+    run_sync(device.name, proxy_cf=cf_name)
+
+    assert zabbix_host(device.name)["monitored_by"] == MONITORED_BY_PROXY
+
+
+def test_a_custom_field_is_ignored_while_proxy_cf_is_unset(
+    proxy_factory, custom_field_factory, device_factory, run_sync, zabbix_host
+):
+    """The paired off state: identical NetBox data, setting left at its default.
+
+    Without this, the test above would pass for an implementation that read
+    every custom field looking for something proxy-shaped.
+    """
+    proxy_name = proxy_factory()
+    cf_name = custom_field_factory(["dcim.device"])
+    device = device_factory()
+    device.custom_fields[cf_name] = proxy_name
+    device.save()
+
+    run_sync(device.name)
+
+    assert zabbix_host(device.name)["monitored_by"] == MONITORED_BY_SERVER
+
+
+def test_proxy_custom_field_falls_back_to_the_site(
+    proxy_factory,
+    custom_field_factory,
+    device_factory,
+    run_sync,
+    zabbix_host,
+    seeded,
+    nb,
+):
+    """A site-level default for every device that does not override it.
+
+    `_set_proxy` checks the device first and the site second (host.py:625-634),
+    which is what makes "one proxy per site" expressible without touching every
+    device. The device's own field is deliberately left empty here.
+    """
+    proxy_name = proxy_factory()
+    cf_name = custom_field_factory(["dcim.device", "dcim.site"])
+    # Refetched rather than reusing the session-scoped Record: that copy keeps
+    # whatever custom_fields it was last saved with, and a later save would send
+    # a field another test's fixture has since deleted.
+    site = nb.dcim.sites.get(seeded["site"].id)
+    site.custom_fields[cf_name] = proxy_name
+    site.save()
+    try:
+        device = device_factory()
+
+        run_sync(device.name, proxy_cf=cf_name)
+
+        assert zabbix_host(device.name)["monitored_by"] == MONITORED_BY_PROXY
+    finally:
+        # The site is session-seeded and shared, so the value has to come back
+        # off it however this test ends. The custom field itself is torn down
+        # by its own fixture, but not before other tests have run.
+        site.custom_fields[cf_name] = None
+        site.save()
+
+
+def test_the_device_custom_field_wins_over_the_site(
+    proxy_factory,
+    custom_field_factory,
+    device_factory,
+    run_sync,
+    zabbix_host,
+    seeded,
+    nb,
+    proxy_id,
+):
+    """Both levels set, to different proxies, so the precedence is observable."""
+    site_proxy = proxy_factory()
+    device_proxy = proxy_factory()
+    cf_name = custom_field_factory(["dcim.device", "dcim.site"])
+    # Refetched rather than reusing the session-scoped Record: that copy keeps
+    # whatever custom_fields it was last saved with, and a later save would send
+    # a field another test's fixture has since deleted.
+    site = nb.dcim.sites.get(seeded["site"].id)
+    site.custom_fields[cf_name] = site_proxy
+    site.save()
+    try:
+        device = device_factory()
+        device.custom_fields[cf_name] = device_proxy
+        device.save()
+
+        run_sync(device.name, proxy_cf=cf_name)
+
+        host = zabbix_host(device.name)
+        assert host["monitored_by"] == MONITORED_BY_PROXY
+        assert host["proxyid"] != "0"
+        assert host["proxyid"] == proxy_id(device_proxy)
+    finally:
+        site.custom_fields[cf_name] = None
+        site.save()
+
+
+def test_the_custom_field_wins_over_the_config_context(
+    proxy_factory, custom_field_factory, device_factory, run_sync, zabbix_host, proxy_id
+):
+    """Config context is the last resort, not the first (host.py:620-641).
+
+    Guessable either way, so it is pinned: `_set_proxy` only consults the
+    config context when the custom field produced nothing.
+    """
+    cf_proxy = proxy_factory()
+    context_proxy = proxy_factory()
+    cf_name = custom_field_factory(["dcim.device"])
+    device = device_factory(config_context={"zabbix": {"proxy": context_proxy}})
+    device.custom_fields[cf_name] = cf_proxy
+    device.save()
+
+    run_sync(device.name, proxy_cf=cf_name)
+
+    assert zabbix_host(device.name)["proxyid"] == proxy_id(cf_proxy)
+
+
+def test_unknown_proxy_name_costs_only_the_proxy_not_the_host(
+    device_factory, run_sync, zabbix_host
+):
+    """A name Zabbix does not have is a warning, and the host syncs anyway.
+
+    This is the right blast radius: a proxy decommissioned in Zabbix but still
+    named in NetBox should not stop the host being monitored by the server.
+    """
+    device = device_factory(config_context={"zabbix": {"proxy": "fn-no-such-proxy"}})
+
+    run_sync(device.name)
+
+    host = zabbix_host(device.name)
+    assert host is not None, "an unresolvable proxy name dropped the host"
+    assert host["monitored_by"] == MONITORED_BY_SERVER
+
+
+def test_proxy_group_takes_priority_over_a_proxy(
+    proxy_factory, device_factory, run_sync, zabbix_host
+):
+    """Both named on one host: the group wins, because it is the HA option.
+
+    `_set_proxy` puts "proxy_group" at the front of the list it walks on Zabbix
+    7+ (host.py:608) and returns on the first match, which is what implements
+    the priority.
+    """
+    proxy_name = proxy_factory()
+    group_name = proxy_factory.group()
+    device = device_factory(
+        config_context={"zabbix": {"proxy": proxy_name, "proxy_group": group_name}}
+    )
+
+    run_sync(device.name)
+
+    host = zabbix_host(device.name)
+    assert host["monitored_by"] == MONITORED_BY_PROXY_GROUP
+    assert host["proxyid"] == "0", "a plain proxy was set alongside the group"
+
+
+def test_proxy_group_from_its_own_custom_field(
+    proxy_factory, custom_field_factory, device_factory, run_sync, zabbix_host
+):
+    """`proxy_group_cf` is a separate setting from `proxy_cf`.
+
+    Set to different field names here so that reading the wrong setting shows
+    up as no proxy group at all rather than as an accidental pass.
+    """
+    group_name = proxy_factory.group()
+    group_cf = custom_field_factory(["dcim.device"])
+    custom_field_factory(["dcim.device"])
+    device = device_factory()
+    device.custom_fields[group_cf] = group_name
+    device.save()
+
+    run_sync(device.name, proxy_group_cf=group_cf)
+
+    assert zabbix_host(device.name)["monitored_by"] == MONITORED_BY_PROXY_GROUP
+
+
+def test_a_changed_proxy_is_updated_on_the_next_run(
+    proxy_factory, device_factory, run_sync, zabbix_host, proxy_id
+):
+    """Moving a device between proxies in NetBox moves it in Zabbix.
+
+    Independent of `full_proxy_sync`: that setting governs *removal*, not
+    reassignment, so this has to work with it off -- which is the default and
+    therefore the case most installations are in.
+    """
+    first = proxy_factory()
+    second = proxy_factory()
+    device = device_factory(config_context={"zabbix": {"proxy": first}})
+    run_sync(device.name)
+    assert zabbix_host(device.name)["proxyid"] == proxy_id(first)
+
+    device.local_context_data = {"zabbix": {"proxy": second}}
+    device.save()
+    run_sync(device.name)
+
+    assert zabbix_host(device.name)["proxyid"] == proxy_id(second)
+
+
+def test_proxy_is_left_alone_when_full_proxy_sync_is_off(
+    proxy_factory, device_factory, run_sync, zabbix_host
+):
+    """NetBox stops naming a proxy; Zabbix keeps the one it has.
+
+    The default, and the conservative half of the setting: a proxy assigned by
+    hand in Zabbix survives a sync that knows nothing about it. Only a warning
+    is logged (host.py:1008).
+    """
+    proxy_name = proxy_factory()
+    device = device_factory(config_context={"zabbix": {"proxy": proxy_name}})
+    run_sync(device.name)
+    assert zabbix_host(device.name)["monitored_by"] == MONITORED_BY_PROXY
+
+    device.local_context_data = {}
+    device.save()
+    run_sync(device.name)
+
+    assert zabbix_host(device.name)["monitored_by"] == MONITORED_BY_PROXY, (
+        "the proxy was removed even though full_proxy_sync is off"
+    )
+
+
+def test_full_proxy_sync_removes_a_proxy_netbox_no_longer_names(
+    proxy_factory, device_factory, run_sync, zabbix_host
+):
+    """The destructive half, and the reason the setting exists.
+
+    Identical to the test above except for the one boolean, so the difference in
+    outcome can only be the setting. This is the only place the sync deletes
+    Zabbix configuration it did not just create, which is why both states are
+    pinned rather than only this one.
+    """
+    proxy_name = proxy_factory()
+    device = device_factory(config_context={"zabbix": {"proxy": proxy_name}})
+    run_sync(device.name, full_proxy_sync=True)
+    assert zabbix_host(device.name)["monitored_by"] == MONITORED_BY_PROXY
+
+    device.local_context_data = {}
+    device.save()
+    run_sync(device.name, full_proxy_sync=True)
+
+    assert proxy_assignment(zabbix_host(device.name)) == (MONITORED_BY_SERVER, "0")

--- a/tests/functional/test_proxies.py
+++ b/tests/functional/test_proxies.py
@@ -39,24 +39,28 @@ def proxy_factory(zapi):
     proxies = []
     groups = []
 
-    def proxy(name: str | None = None) -> str:
-        name = name or f"fn-proxy-{uuid4().hex[:8]}"
-        # operating_mode 0 is an active proxy, which needs no address or port:
-        # nothing ever connects to it, and the sync only reads its name.
-        proxies.append(zapi.proxy.create(name=name, operating_mode=0)["proxyids"][0])
-        return name
+    class ProxyFactory:
+        """Called for a proxy, `.group()` for a proxy group."""
 
-    def group(name: str | None = None) -> str:
-        name = name or f"fn-pgroup-{uuid4().hex[:8]}"
-        groups.append(
-            zapi.proxygroup.create(name=name, failover_delay="10s", min_online="1")[
-                "proxy_groupids"
-            ][0]
-        )
-        return name
+        def __call__(self, name: str | None = None) -> str:
+            name = name or f"fn-proxy-{uuid4().hex[:8]}"
+            # operating_mode 0 is an active proxy, which needs no address or
+            # port: nothing ever connects to it, and the sync only reads its name.
+            proxies.append(
+                zapi.proxy.create(name=name, operating_mode=0)["proxyids"][0]
+            )
+            return name
 
-    proxy.group = group
-    yield proxy
+        def group(self, name: str | None = None) -> str:
+            name = name or f"fn-pgroup-{uuid4().hex[:8]}"
+            groups.append(
+                zapi.proxygroup.create(name=name, failover_delay="10s", min_online="1")[
+                    "proxy_groupids"
+                ][0]
+            )
+            return name
+
+    yield ProxyFactory()
 
     for proxyid in proxies:
         zapi.proxy.delete(proxyid)

--- a/tests/functional/test_status_and_journal.py
+++ b/tests/functional/test_status_and_journal.py
@@ -1,0 +1,296 @@
+"""What a NetBox status does to a Zabbix host, and what the run writes back.
+
+Three settings decide a host's fate before any attribute is synced, and all
+three are lists or booleans a user is expected to edit:
+
+- `zabbix_device_removal` -- statuses that delete the Zabbix host entirely.
+- `zabbix_device_disable` -- statuses that keep the host but disable it.
+- `create_hostgroups` -- whether a missing hostgroup is created or is fatal.
+
+The defaults are exercised incidentally elsewhere (an "active" device syncs
+enabled). What is not exercised is the *setting*: a status list is only tested
+if a status moves between lists and the outcome moves with it. So each test
+below drives a status the default lists put somewhere else, which is the only
+way to tell "the setting was read" from "the default happened to agree".
+
+`create_journal` is here for the same reason -- it is the one setting whose
+effect lands in NetBox rather than Zabbix, so it is asserted through
+`nb.extras.journal_entries` rather than through the Zabbix host.
+"""
+
+import pytest
+
+pytestmark = pytest.mark.functional
+
+ZABBIX_STATUS_ENABLED = "0"
+ZABBIX_STATUS_DISABLED = "1"
+
+# NetBox slug -> the label `Host.status` actually compares against (host.py:84).
+# The config lists are written in labels, not slugs, which is a distinction a
+# user only discovers by getting it wrong.
+DECOMMISSIONING = ("decommissioning", "Decommissioning")
+OFFLINE = ("offline", "Offline")
+ACTIVE = ("active", "Active")
+
+
+@pytest.fixture
+def zabbix_hostgroups(zapi):
+    """Read hostgroups back, and delete any the test caused to be created.
+
+    Hostgroup creation is the one sync side effect that outlives the host: a
+    group stays in Zabbix after its last host is deleted, so without this the
+    Zabbix side accumulates a group per run and `create_hostgroups=False` tests
+    start passing for the wrong reason -- the group a previous run created is
+    already there.
+    """
+    created = []
+
+    def _get(name: str):
+        groups = zapi.hostgroup.get(filter={"name": name}, output=["groupid", "name"])
+        if groups:
+            created.append(groups[0]["groupid"])
+        return groups[0] if groups else None
+
+    yield _get
+
+    for groupid in created:
+        zapi.hostgroup.delete(groupid)
+
+
+def test_status_in_removal_list_deletes_an_existing_host(
+    nb, device_factory, run_sync, zabbix_host
+):
+    """The host is created, then the same device syncs again as removable.
+
+    Two syncs rather than one: a device that starts out removable never reaches
+    Zabbix at all, which would pass this test without the deletion path ever
+    running. The point is that an *existing* host is torn down.
+    """
+    device = device_factory()
+    run_sync(device.name)
+    assert zabbix_host(device.name) is not None, "setup: first sync did not create it"
+
+    device.status = OFFLINE[0]
+    device.save()
+    run_sync(device.name, zabbix_device_removal=[OFFLINE[1]])
+
+    assert zabbix_host(device.name) is None
+    # The NetBox side of the teardown: leaving a stale host ID behind would make
+    # the next sync fetch a host that no longer exists.
+    assert nb.dcim.devices.get(device.id).custom_fields["zabbix_hostid"] is None
+
+
+def test_status_out_of_the_removal_list_survives(device_factory, run_sync, zabbix_host):
+    """The same status as above, with the setting left at its default.
+
+    "Offline" is in the *disable* default, not the removal default, so this is
+    the paired off-state: the host must live, and be disabled rather than gone.
+    Without this the test above would pass for a device that never synced.
+    """
+    device = device_factory(status=OFFLINE[0])
+
+    run_sync(device.name)
+
+    host = zabbix_host(device.name)
+    assert host is not None, "an offline device was removed under the default lists"
+    assert host["status"] == ZABBIX_STATUS_DISABLED
+
+
+def test_removal_status_on_a_host_zabbix_never_had_is_a_no_op(
+    device_factory, run_sync, zabbix_host
+):
+    """A device that is removable on its first sync is skipped, not an error.
+
+    `_sync_host` returns early with no Zabbix ID rather than calling cleanup
+    (core.py:237-247). The run has to continue: an inventory full of
+    decommissioned devices is ordinary, and each one raising would end it.
+    """
+    removable = device_factory(status=DECOMMISSIONING[0])
+
+    run_sync(removable.name)
+
+    assert zabbix_host(removable.name) is None
+
+
+def test_status_in_a_custom_disable_list_disables_the_host(
+    device_factory, run_sync, zabbix_host
+):
+    """ "Active" is in no default list; putting it in the disable list must bite.
+
+    Chosen deliberately over a status that is already disabled by default --
+    that one cannot distinguish the setting being read from the default
+    applying.
+    """
+    device = device_factory(status=ACTIVE[0])
+
+    run_sync(device.name, zabbix_device_disable=[ACTIVE[1]])
+
+    assert zabbix_host(device.name)["status"] == ZABBIX_STATUS_DISABLED
+
+
+def test_emptying_the_disable_list_keeps_an_offline_host_enabled(
+    device_factory, run_sync, zabbix_host
+):
+    """The off state of the disable feature: an empty list disables nothing."""
+    device = device_factory(status=OFFLINE[0])
+
+    run_sync(device.name, zabbix_device_disable=[])
+
+    assert zabbix_host(device.name)["status"] == ZABBIX_STATUS_ENABLED
+
+
+def test_a_disabled_host_is_re_enabled_when_its_status_changes(
+    device_factory, run_sync, zabbix_host
+):
+    """Status is reconciled on every run, not only set at creation.
+
+    `consistency_check` compares the stored status against the computed one
+    (host.py:915). A host disabled by a previous run has to come back when the
+    NetBox status moves out of the disable list, or a device stays dark in
+    Zabbix after being brought back into service.
+    """
+    device = device_factory(status=OFFLINE[0])
+    run_sync(device.name)
+    assert zabbix_host(device.name)["status"] == ZABBIX_STATUS_DISABLED
+
+    device.status = ACTIVE[0]
+    device.save()
+    run_sync(device.name)
+
+    assert zabbix_host(device.name)["status"] == ZABBIX_STATUS_ENABLED
+
+
+# A hostgroup format has to name items from a fixed allow-list (tools.py:210),
+# so "the device's own name" is not available to make a group unique per test.
+# A custom field is: its name passes the allow-list and its *value* is per
+# device, which is what these two tests need -- a group name Zabbix has
+# certainly never seen, so its presence or absence afterwards means something.
+GROUP_CF_TYPES = ["dcim.device"]
+
+
+def test_missing_hostgroup_is_created_when_enabled(
+    zabbix_hostgroups, custom_field_factory, device_factory, run_sync, zabbix_host
+):
+    """`create_hostgroups` on: a group Zabbix has never seen is created.
+
+    `zabbix_hostgroups` is requested first on purpose: Zabbix refuses to delete
+    a group that still holds a host, so the group has to go after
+    device_factory's hosts. Finalizers run in reverse setup order, so first
+    here means last at teardown.
+    """
+    cf_name = custom_field_factory(GROUP_CF_TYPES)
+    device = device_factory()
+    group_name = f"grp-{device.name}"
+    device.custom_fields[cf_name] = group_name
+    device.save()
+
+    run_sync(device.name, hostgroup_format=cf_name)
+
+    assert zabbix_hostgroups(group_name) is not None, "the group was not created"
+    groups = [group["name"] for group in zabbix_host(device.name)["hostgroups"]]
+    assert groups == [group_name]
+
+
+def test_missing_hostgroup_costs_the_host_when_creation_is_disabled(
+    # Requested first so it tears down last; see the note in the test above.
+    zabbix_hostgroups,
+    custom_field_factory,
+    device_factory,
+    tag_factory,
+    sync_runner,
+    zabbix_host,
+    zapi,
+):
+    """`create_hostgroups` off: the host is skipped rather than created groupless.
+
+    This is the setting's whole point -- a Zabbix account without hostgroup
+    write permission would otherwise fail the API call, so the sync must stop
+    short of trying. What has to be shown is that it costs *only* that host, so
+    a second device, whose group does exist, is synced in the same run.
+
+    Both devices carry a shared NetBox tag and the run is filtered on it, which
+    is what puts them in one run rather than two.
+    """
+    cf_name = custom_field_factory(GROUP_CF_TYPES)
+    tag = tag_factory()
+    orphan = device_factory(tags=[tag.id])
+    ordinary = device_factory(tags=[tag.id])
+    for device, group in ((orphan, "grp-absent"), (ordinary, "grp-present")):
+        device.custom_fields[cf_name] = f"{group}-{device.name}"
+        device.save()
+
+    # Pre-created by hand, so the sync finds this one rather than making it.
+    existing_group = f"grp-present-{ordinary.name}"
+    zapi.hostgroup.create(name=existing_group)
+
+    sync_runner(
+        device_filter={"tag": tag.slug},
+        create_hostgroups=False,
+        hostgroup_format=cf_name,
+    )
+
+    assert zabbix_host(orphan.name) is None, "host created despite its group missing"
+    assert zabbix_hostgroups(f"grp-absent-{orphan.name}") is None, (
+        "group created despite create_hostgroups being off"
+    )
+
+    host = zabbix_host(ordinary.name)
+    assert host is not None, "the run stopped instead of skipping just the one host"
+    assert [group["name"] for group in host["hostgroups"]] == [existing_group]
+    # Registers the hand-made group with the fixture so it is torn down too.
+    assert zabbix_hostgroups(existing_group) is not None
+
+
+def test_journal_entry_written_on_creation(nb, device_factory, run_sync):
+    """`create_journal` on: the sync leaves a trail in NetBox.
+
+    Asserted through `nb.extras.journal_entries` rather than a log line: the
+    setting's purpose is a record a NetBox user can see without reading the
+    sync's output.
+    """
+    device = device_factory()
+
+    run_sync(device.name, create_journal=True)
+
+    entries = list(
+        nb.extras.journal_entries.filter(
+            assigned_object_type="dcim.device", assigned_object_id=device.id
+        )
+    )
+    assert entries, "create_journal was on but NetBox has no entry for the device"
+    assert any("Zabbix" in entry.comments for entry in entries)
+
+
+def test_no_journal_entries_when_disabled(nb, device_factory, run_sync):
+    """The off state, and the default -- so the test above proves the setting."""
+    device = device_factory()
+
+    run_sync(device.name)
+
+    assert not list(
+        nb.extras.journal_entries.filter(
+            assigned_object_type="dcim.device", assigned_object_id=device.id
+        )
+    )
+
+
+def test_journal_entry_written_on_removal(nb, device_factory, run_sync, zabbix_host):
+    """Deletion is journalled too, with `warning` severity (host.py:423).
+
+    The severity matters: a deleted host is the one sync outcome a NetBox user
+    would want to notice in the journal without reading it.
+    """
+    device = device_factory()
+    run_sync(device.name, create_journal=True)
+
+    device.status = DECOMMISSIONING[0]
+    device.save()
+    run_sync(device.name, create_journal=True)
+
+    assert zabbix_host(device.name) is None
+    entries = list(
+        nb.extras.journal_entries.filter(
+            assigned_object_type="dcim.device", assigned_object_id=device.id
+        )
+    )
+    assert "warning" in [entry.kind.value for entry in entries]

--- a/tests/functional/test_templates.py
+++ b/tests/functional/test_templates.py
@@ -1,0 +1,208 @@
+"""Where a device's Zabbix templates come from, and what happens when they don't.
+
+`template_cf` names the NetBox custom field holding the template name. It is the
+only one of the template settings not covered by test_config_context.py, and it
+is easy to get wrong in a way that looks like it works: the seed data uses the
+default field name, so a sync that ignored the setting entirely would still pass
+any test that left it at its default. Every test here therefore uses a custom
+field with a name the default would never find.
+
+The custom field lives on the *device type*, not the device (host.py:275), which
+is the other thing worth pinning -- it means templates are chosen per model, and
+a device cannot override its type's template except through config context.
+"""
+
+import pytest
+
+from tests.functional.bootstrap import seed_netbox
+
+pytestmark = pytest.mark.functional
+
+# A second real template, used wherever a test needs to tell "the configured
+# template arrived" from "the seeded default arrived". ICMP Ping is chosen
+# because it binds to no particular interface type, so it can be linked
+# alongside or instead of the seeded SNMP template without Zabbix objecting.
+ALTERNATE_TEMPLATE = "ICMP Ping"
+
+# For the one test that links two templates at once. Zabbix rejects a host
+# inheriting the same item key twice, and "Linux by SNMP" already carries the
+# icmpping items -- so the second template has to be one that overlaps nothing,
+# not merely one that is different.
+NON_OVERLAPPING_TEMPLATE = "Zabbix server health"
+
+
+@pytest.fixture
+def device_type_cf(nb, custom_field_factory, seeded):
+    """A custom field on the device type, set to a template name.
+
+    Yields a `(field_name, set_value)` pair. The device type is session-seeded
+    and shared, so the value is cleared afterwards however the test ends --
+    otherwise the next test's device inherits a template it never asked for.
+    """
+    cf_name = custom_field_factory(["dcim.devicetype"])
+    device_type_id = seeded["device_type"].id
+
+    def set_value(value: str) -> None:
+        # Refetched each time: the session-scoped Record keeps whatever
+        # custom_fields it last saved, including ones since deleted.
+        device_type = nb.dcim.device_types.get(device_type_id)
+        device_type.custom_fields[cf_name] = value
+        device_type.save()
+
+    yield cf_name, set_value
+
+    device_type = nb.dcim.device_types.get(device_type_id)
+    device_type.custom_fields[cf_name] = None
+    device_type.save()
+
+
+def template_names(host: dict) -> list[str]:
+    return sorted(template["host"] for template in host["parentTemplates"])
+
+
+def test_templates_read_from_the_configured_custom_field(
+    device_type_cf, device_factory, run_sync, zabbix_host
+):
+    """A non-default field name is honoured, and its value becomes the template.
+
+    The chosen template differs from the seeded default too, so this fails both
+    if the setting is ignored and if the field is read but its value is not.
+    """
+    cf_name, set_value = device_type_cf
+    set_value(ALTERNATE_TEMPLATE)
+    device = device_factory()
+
+    run_sync(device.name, template_cf=cf_name)
+
+    assert template_names(zabbix_host(device.name)) == [ALTERNATE_TEMPLATE]
+
+
+def test_the_default_field_is_not_consulted_when_the_setting_points_elsewhere(
+    device_type_cf, device_factory, run_sync, zabbix_host
+):
+    """The seeded `zabbix_template` field is ignored once `template_cf` moves.
+
+    The device type carries both fields with different templates, so a sync
+    that fell back to the default name -- or read both -- lands a different
+    answer than a sync that read only the configured one.
+    """
+    cf_name, set_value = device_type_cf
+    set_value(ALTERNATE_TEMPLATE)
+    device = device_factory()
+
+    run_sync(device.name, template_cf=cf_name)
+
+    templates = template_names(zabbix_host(device.name))
+    assert templates == [ALTERNATE_TEMPLATE]
+    assert seed_netbox.ZABBIX_TEMPLATE not in templates
+
+
+def test_a_missing_custom_field_costs_only_its_own_host(
+    device_factory, run_sync, zabbix_host, tag_factory, sync_runner
+):
+    """Pointing `template_cf` at a field that does not exist skips the host.
+
+    `_get_templates_cf` raises `TemplateError`, which is a `SyncError`, so the
+    per-host handler catches it and the run continues (host.py:283). That is
+    the containment this test is really about: `template_cf` is global, so a
+    typo in it would otherwise take down the whole run.
+
+    Both devices share a tag and one run, so "the run continued" is observed
+    rather than assumed -- except that here the typo affects every device
+    equally, so what is asserted is that the run *ended normally* with both
+    hosts skipped, not that one survived.
+    """
+    tag = tag_factory()
+    first = device_factory(tags=[tag.id])
+    second = device_factory(tags=[tag.id])
+
+    sync_runner(device_filter={"tag": tag.slug}, template_cf="cf_does_not_exist")
+
+    assert zabbix_host(first.name) is None
+    assert zabbix_host(second.name) is None
+
+
+def test_an_empty_custom_field_value_costs_only_its_own_host(
+    device_type_cf, device_factory, run_sync, zabbix_host
+):
+    """The field exists but is unset: no template, so no host.
+
+    A device type nobody has filled in yet is the ordinary way to reach this,
+    and it must not be an error -- Zabbix rejects a host with no template, so
+    skipping is the only option. Pinned because the alternative implementation,
+    creating the host templateless, fails at the API instead.
+    """
+    cf_name, _ = device_type_cf
+    device = device_factory()
+
+    run_sync(device.name, template_cf=cf_name)
+
+    assert zabbix_host(device.name) is None
+
+
+def test_config_context_still_overrules_a_custom_template_field(
+    device_type_cf, device_factory, run_sync, zabbix_host
+):
+    """`templates_config_context_overrule` works against any field name.
+
+    The overrule path and the `template_cf` path are separate reads, so this
+    checks they compose: a renamed field must still lose to the config context
+    when the overrule setting says it should.
+    """
+    cf_name, set_value = device_type_cf
+    set_value(ALTERNATE_TEMPLATE)
+    device = device_factory(
+        config_context={"zabbix": {"templates": [seed_netbox.ZABBIX_TEMPLATE]}}
+    )
+
+    run_sync(
+        device.name,
+        template_cf=cf_name,
+        templates_config_context_overrule=True,
+    )
+
+    assert template_names(zabbix_host(device.name)) == [seed_netbox.ZABBIX_TEMPLATE]
+
+
+def test_multiple_templates_from_config_context_all_reach_zabbix(
+    device_factory, run_sync, zabbix_host
+):
+    """A list of templates is linked in full, not just its first entry.
+
+    The custom field can only hold one template name, so a multi-template host
+    has to come from config context -- which makes this the only path where the
+    list handling in `zbx_template_prepper` is exercised end to end.
+    """
+    device = device_factory(
+        config_context={
+            "zabbix": {
+                "templates": [seed_netbox.ZABBIX_TEMPLATE, NON_OVERLAPPING_TEMPLATE]
+            }
+        }
+    )
+
+    run_sync(device.name, templates_config_context=True)
+
+    assert template_names(zabbix_host(device.name)) == sorted(
+        [seed_netbox.ZABBIX_TEMPLATE, NON_OVERLAPPING_TEMPLATE]
+    )
+
+
+def test_an_unknown_template_name_costs_only_its_own_host(
+    device_factory, run_sync, zabbix_host
+):
+    """A template Zabbix does not have skips the host rather than the run.
+
+    The realistic cause is a template renamed in Zabbix while NetBox still
+    names the old one, which is a per-device data problem and has to stay one.
+    """
+    device = device_factory(
+        config_context={"zabbix": {"templates": ["fn-no-such-template"]}}
+    )
+    ordinary = device_factory()
+
+    run_sync(device.name, templates_config_context=True)
+    run_sync(ordinary.name)
+
+    assert zabbix_host(device.name) is None
+    assert zabbix_host(ordinary.name) is not None

--- a/tests/functional/test_vm_sync.py
+++ b/tests/functional/test_vm_sync.py
@@ -1,0 +1,248 @@
+"""Virtual machine sync: the VM maps, and where VMs diverge from devices.
+
+A VM is not a device with a different endpoint. It takes a different branch in
+`start()` (core.py:348), a different class, and four different config keys --
+`vm_inventory_map`, `vm_usermacro_map`, `vm_tag_map` and `vm_hostgroup_format`.
+Every one of those is a separate mapping that no device test can reach.
+
+Two of the divergences are the kind only a real Zabbix will fail on:
+
+- **A VM defaults to an agent interface**, where a device defaults to SNMP
+  (virtual_machine.py:44 against host.py:496). Zabbix refuses to link an agent
+  template to a host with no agent interface and vice versa, so the interface
+  default and the template have to agree -- and the seeded VM template is an
+  agent one for exactly that reason.
+- **A VM's templates come only from its config context.** `set_vm_template`
+  skips the custom field lookup devices use, so a VM with no `zabbix` context is
+  dropped by core.py:371 before Zabbix sees it. That is why `vm_factory` gives
+  every VM a context by default; see `vm_context` in conftest.
+"""
+
+import pytest
+
+from tests.functional.bootstrap import seed_netbox
+from tests.functional.conftest import (
+    macro_values,
+    strip_ip_mask,
+    tag_pairs,
+    vm_context,
+)
+
+pytestmark = pytest.mark.functional
+
+ZABBIX_AGENT_INTERFACE = "1"
+ZABBIX_SNMP_INTERFACE = "2"
+AGENT_PORT = "10050"
+
+INVENTORY_MANUAL_CONFIG = {"inventory_sync": True, "inventory_mode": "manual"}
+
+
+def test_vm_created_in_zabbix(vm_factory, run_vm_sync, zabbix_host):
+    vm = vm_factory()
+
+    run_vm_sync(vm.name)
+
+    host = zabbix_host(vm.name)
+    assert host is not None, "the VM did not reach Zabbix"
+    assert [t["host"] for t in host["parentTemplates"]] == [
+        seed_netbox.ZABBIX_VM_TEMPLATE
+    ]
+
+
+def test_vm_gets_an_agent_interface_by_default(vm_factory, run_vm_sync, zabbix_host):
+    """The VM default, and the opposite of the device default.
+
+    Asserting the port as well as the type: an agent interface on the SNMP port
+    would still report type 1 while talking to nothing.
+    """
+    vm = vm_factory(address="10.1.0.5/24")
+
+    run_vm_sync(vm.name)
+
+    interfaces = zabbix_host(vm.name)["interfaces"]
+    assert [i["type"] for i in interfaces] == [ZABBIX_AGENT_INTERFACE]
+    assert interfaces[0]["ip"] == strip_ip_mask("10.1.0.5/24")
+    assert interfaces[0]["port"] == AGENT_PORT
+
+
+def test_vm_snmp_interface_from_config_context(vm_factory, run_vm_sync, zabbix_host):
+    """A config context still overrules the agent default (virtual_machine.py:54).
+
+    The template has to change with it: Zabbix rejects the agent template on a
+    host whose only interface is SNMP, so this doubles as proof that the two
+    halves of the context are applied together.
+    """
+    vm = vm_factory(
+        config_context={
+            "zabbix": {
+                "templates": [seed_netbox.ZABBIX_TEMPLATE],
+                "interface_type": 2,
+                "interface_port": 161,
+                "snmp": {"community": "public", "version": 2, "bulk": 1},
+            }
+        }
+    )
+
+    run_vm_sync(vm.name)
+
+    interfaces = zabbix_host(vm.name)["interfaces"]
+    assert [i["type"] for i in interfaces] == [ZABBIX_SNMP_INTERFACE]
+    assert interfaces[0]["port"] == "161"
+
+
+def test_vm_without_config_context_is_skipped(vm_factory, run_vm_sync, zabbix_host):
+    """No context means no template, and core.py:371 drops the VM.
+
+    The off state of `vm_context`: it is what makes every other test in this
+    file meaningful, so it is worth one test of its own rather than a comment.
+    """
+    vm = vm_factory(config_context=None)
+
+    run_vm_sync(vm.name)
+
+    assert zabbix_host(vm.name) is None
+
+
+def test_vms_untouched_when_sync_vms_disabled(vm_factory, run_vm_sync, zabbix_host):
+    """The off state of the switch every other test here turns on."""
+    vm = vm_factory()
+
+    run_vm_sync(vm.name, sync_vms=False)
+
+    assert zabbix_host(vm.name) is None
+
+
+def test_vm_hostgroup_from_cluster_type_and_cluster(
+    vm_factory, run_vm_sync, zabbix_host
+):
+    """The default vm_hostgroup_format, which no device can produce.
+
+    `cluster_type` is reached as `self.nb.cluster.type.name`
+    (hostgroups.py:88) -- attribute access, so pynetbox lazily fetches the
+    cluster. Worth contrasting with the tag map, which cannot reach the same
+    field: see test_default_maps.py.
+    """
+    vm = vm_factory()
+
+    run_vm_sync(vm.name)
+
+    groups = [group["name"] for group in zabbix_host(vm.name)["hostgroups"]]
+    assert groups == [seed_netbox.EXPECTED_VM_HOSTGROUP]
+
+
+def test_vm_hostgroup_format_is_separate_from_the_device_one(
+    vm_factory, run_vm_sync, zabbix_host
+):
+    """`hostgroup_format` must not leak into VMs.
+
+    The device format here would resolve for a VM -- it has a site and a role --
+    but names `manufacturer`, which is a device-only option (hostgroups.py:80).
+    If the VM read it, the sync would raise HostgroupError rather than quietly
+    grouping wrong, so the assertion is that the VM synced at all.
+    """
+    vm = vm_factory()
+
+    run_vm_sync(vm.name, vm_hostgroup_format="cluster/role")
+
+    groups = [group["name"] for group in zabbix_host(vm.name)["hostgroups"]]
+    assert groups == [f"{seed_netbox.CLUSTER_NAME}/{seed_netbox.ROLE_NAME}"]
+
+
+def test_vm_inventory_map_is_used_not_the_device_map(
+    vm_factory, run_vm_sync, zabbix_host
+):
+    """VirtualMachine._inventory_map returns vm_inventory_map (virtual_machine.py:24).
+
+    Both maps are set, to different Zabbix fields, so a VM reading the device
+    map would be caught rather than merely failing to be proven.
+    """
+    vm = vm_factory(comments="vm note")
+
+    run_vm_sync(
+        vm.name,
+        **INVENTORY_MANUAL_CONFIG,
+        vm_inventory_map={"comments": "notes"},
+        device_inventory_map={"comments": "location"},
+    )
+
+    inventory = zabbix_host(vm.name)["inventory"]
+    assert inventory["notes"] == "vm note"
+    assert inventory["location"] == ""
+
+
+def test_vm_usermacro_map_is_used_not_the_device_map(
+    vm_factory, run_vm_sync, zabbix_host
+):
+    vm = vm_factory(memory=4096)
+
+    run_vm_sync(
+        vm.name,
+        usermacro_sync=True,
+        vm_usermacro_map={"memory": "{$TOTAL_MEMORY}"},
+        device_usermacro_map={"memory": "{$WRONG_MAP}"},
+    )
+
+    macros = macro_values(zabbix_host(vm.name))
+    assert macros == {"{$TOTAL_MEMORY}": "4096"}
+
+
+def test_vm_tag_map_is_used_not_the_device_map(vm_factory, run_vm_sync, zabbix_host):
+    vm = vm_factory()
+
+    run_vm_sync(
+        vm.name,
+        tag_sync=True,
+        tag_name=None,
+        vm_tag_map={"cluster/name": "cluster"},
+        device_tag_map={"cluster/name": "wrong_map"},
+    )
+
+    assert tag_pairs(zabbix_host(vm.name)) == {
+        ("cluster", seed_netbox.CLUSTER_NAME.lower())
+    }
+
+
+def test_vm_memory_is_stringified_for_zabbix(vm_factory, run_vm_sync, zabbix_host):
+    """`memory` is an int in NetBox and must reach Zabbix as a string.
+
+    The default vm_usermacro_map ships this mapping, and it is the only default
+    map entry on either side whose NetBox value is not already a string. Zabbix
+    rejects a non-string macro value, so field_mapper's str() is load-bearing
+    here rather than cosmetic.
+    """
+    vm = vm_factory(memory=2048)
+
+    run_vm_sync(vm.name, usermacro_sync=True, vm_usermacro_map={"memory": "{$MEM}"})
+
+    assert macro_values(zabbix_host(vm.name)) == {"{$MEM}": "2048"}
+
+
+def test_vm_config_context_macros_are_rendered(vm_factory, run_vm_sync, zabbix_host):
+    """Jinja rendering reaches VMs too -- core.py:366 is the VM branch's call."""
+    vm = vm_factory(config_context=vm_context(usermacros={"{$VM}": "{{ data.name }}"}))
+
+    run_vm_sync(vm.name, usermacro_sync=True, render_config_context=True)
+
+    assert macro_values(zabbix_host(vm.name))["{$VM}"] == vm.name
+
+
+def test_vm_status_maps_to_zabbix_status(vm_factory, run_vm_sync, zabbix_host):
+    """A VM in a disable-listed status syncs as a disabled host, not a missing one."""
+    vm = vm_factory(status="offline")
+
+    run_vm_sync(vm.name)
+
+    assert zabbix_host(vm.name)["status"] == "1"
+
+
+def test_vm_removal_status_deletes_the_host(vm_factory, run_vm_sync, zabbix_host):
+    """A VM moved into a removal status is deleted from Zabbix on the next run."""
+    vm = vm_factory()
+    run_vm_sync(vm.name)
+    assert zabbix_host(vm.name) is not None, "precondition: the VM synced"
+
+    vm.status = "decommissioning"
+    vm.save()
+    run_vm_sync(vm.name)
+
+    assert zabbix_host(vm.name) is None

--- a/tests/test_jinja_filters.py
+++ b/tests/test_jinja_filters.py
@@ -1,0 +1,159 @@
+"""Tests for the custom Jinja2 filters offered to config context rendering.
+
+These are the filters users reach for when a config context has to reshape
+NetBox data before it becomes a Zabbix macro or item. They are registered by
+name into the Jinja environment (tools.py:89), so a rename here is a silent
+break in every config context that used the old name -- worth pinning even
+where the implementation is a one-liner.
+
+The functional suite proves the filters are *loaded*; these prove they are
+correct, including the edge cases a live sync would only hit occasionally.
+"""
+
+import pytest
+
+from netbox_zabbix_sync.modules.jinja_filters import (
+    dict_keys,
+    json_path,
+    regex_replace,
+    regex_search,
+    strftime,
+)
+
+
+class TestDictKeys:
+    """dict_keys filters a list of dicts down to the named keys."""
+
+    def test_single_key_as_string_is_accepted(self):
+        """A bare string is treated as a one-key list, not iterated per char."""
+        data = [{"name": "eth0", "type": "1000base-t"}]
+        assert dict_keys(data, "name") == [{"name": "eth0"}]
+
+    def test_multiple_keys(self):
+        data = [
+            {"name": "eth0", "type": "1000base-t", "enabled": True},
+            {"name": "eth1", "type": "10gbase-x-sfpp", "enabled": False},
+        ]
+        assert dict_keys(data, ["name", "type"]) == [
+            {"name": "eth0", "type": "1000base-t"},
+            {"name": "eth1", "type": "10gbase-x-sfpp"},
+        ]
+
+    def test_missing_keys_are_omitted_rather_than_nulled(self):
+        """A dict lacking the key contributes only what it has."""
+        data = [{"name": "eth0"}, {"name": "eth1", "type": "virtual"}]
+        assert dict_keys(data, ["name", "type"]) == [
+            {"name": "eth0"},
+            {"name": "eth1", "type": "virtual"},
+        ]
+
+    def test_falsy_values_are_dropped(self):
+        """Documents a real edge: the filter keeps truthy values only.
+
+        `enabled: False` and an empty name are dropped rather than carried
+        through, so a config context cannot use this filter to render a
+        boolean. Pinned because it is surprising, not because it is desirable.
+        """
+        data = [{"name": "eth0", "enabled": False, "mtu": 0}]
+        assert dict_keys(data, ["name", "enabled", "mtu"]) == [{"name": "eth0"}]
+
+    def test_dict_reduced_to_nothing_is_dropped_entirely(self):
+        data = [{"name": "eth0"}, {"other": "value"}]
+        assert dict_keys(data, ["name"]) == [{"name": "eth0"}]
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            pytest.param([], id="empty-list"),
+            pytest.param([{"other": "value"}], id="no-matching-keys"),
+            pytest.param("not-a-list", id="not-a-list"),
+            pytest.param({"name": "eth0"}, id="bare-dict"),
+        ],
+    )
+    def test_returns_empty_string_when_nothing_matches(self, data):
+        """The no-op return is `""`, not `[]` or None.
+
+        It is what lands in the rendered JSON, so it has to stay a value the
+        json.loads round trip survives (tools.py:91-93).
+        """
+        assert dict_keys(data, ["name"]) == ""
+
+    def test_no_keys_requested_is_a_noop(self):
+        assert dict_keys([{"name": "eth0"}]) == ""
+
+
+class TestJsonPath:
+    """json_path exposes JSONPath queries to a config context."""
+
+    def test_finds_nested_values(self):
+        data = {"interfaces": [{"name": "eth0"}, {"name": "eth1"}]}
+        assert json_path(data, "$.interfaces[*].name") == ["eth0", "eth1"]
+
+    def test_filter_expression(self):
+        data = {
+            "interfaces": [
+                {"name": "eth0", "enabled": True},
+                {"name": "eth1", "enabled": False},
+            ]
+        }
+        assert json_path(data, "$.interfaces[?@.enabled == true].name") == ["eth0"]
+
+    def test_no_match_returns_empty_list(self):
+        assert json_path({"a": 1}, "$.nope") == []
+
+
+class TestRegexReplace:
+    def test_replaces_all_occurrences(self):
+        assert regex_replace("a-b-c", "-", "_") == "a_b_c"
+
+    def test_anchored_pattern(self):
+        assert regex_replace("SN-ABC-123", "^SN-", "") == "ABC-123"
+
+    def test_capture_group_backreference(self):
+        assert regex_replace("host01.example.com", r"^([^.]+)\..*$", r"\1") == "host01"
+
+    def test_no_match_returns_input_unchanged(self):
+        assert regex_replace("hostname", "^SN-", "") == "hostname"
+
+
+class TestRegexSearch:
+    def test_returns_the_match_only(self):
+        assert regex_search("device-42-rack", r"\d+") == "42"
+
+    def test_no_match_returns_empty_string(self):
+        """`""` rather than None: the result is rendered into JSON."""
+        assert regex_search("device", r"\d+") == ""
+
+    def test_returns_first_match(self):
+        assert regex_search("a1 b2", r"[a-z]\d") == "a1"
+
+
+class TestStrftime:
+    def test_default_format(self):
+        assert strftime("2024-03-01T14:30:00Z") == "2024-03-01 14:30:00"
+
+    def test_custom_format(self):
+        assert strftime("2024-03-01T14:30:00Z", "%d/%m/%Y") == "01/03/2024"
+
+    def test_timezone_is_dropped_not_converted(self):
+        """The offset is discarded and the wall-clock time kept as written.
+
+        `date.replace(tzinfo=None)` drops the zone without converting, so a
+        NetBox timestamp renders as its original local time. Worth pinning: the
+        alternative reading -- that it converts to UTC -- would shift every
+        rendered timestamp by the offset.
+        """
+        assert strftime("2024-03-01T14:30:00+02:00") == "2024-03-01 14:30:00"
+
+    def test_parses_a_netbox_style_timestamp(self):
+        """NetBox serialises `last_updated` with microseconds and an offset."""
+        assert strftime("2024-03-01T14:30:00.123456+00:00", "%Y-%m-%d") == "2024-03-01"
+
+    def test_invalid_date_raises(self):
+        """A bad date is an error, not a silent empty string.
+
+        The raise is what core.py turns into a skipped host with a logged
+        reason (core.py:198), rather than a host synced with a wrong value.
+        """
+        with pytest.raises(ValueError, match="Unknown string format"):
+            strftime("not-a-date")

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -4,6 +4,7 @@ import pytest
 
 from netbox_zabbix_sync.modules.exceptions import JinjaRenderError
 from netbox_zabbix_sync.modules.tools import (
+    build_path,
     field_mapper,
     jinjafy_config_context,
     sanatize_log_output,
@@ -238,3 +239,68 @@ class TestJinjafyConfigContext:
         """
         nb = DummyNB(config_context=config_context)
         assert jinjafy_config_context(nb) == {}
+
+
+def region(name: str, depth: int, parent: str | None):
+    """One entry of the flat recordset build_path walks.
+
+    Mirrors what convert_recordset produces from a pynetbox region: a dict with
+    the record's own `name`, its `_depth` in the tree, and `parent` -- which is
+    a Record whose str() is the parent's name, so a plain string stands in.
+    """
+    return {"name": name, "_depth": depth, "parent": parent}
+
+
+class TestBuildPath:
+    """build_path reconstructs a region/site-group ancestry for a hostgroup."""
+
+    def test_top_level_object_is_its_own_path(self):
+        records = [region("EU", 0, None)]
+        assert build_path("EU", records) == ["EU"]
+
+    def test_walks_up_through_every_parent(self):
+        records = [
+            region("EU", 0, None),
+            region("NL", 1, "EU"),
+            region("AMS", 2, "NL"),
+        ]
+        assert build_path("AMS", records) == ["EU", "NL", "AMS"]
+
+    def test_returns_only_the_ancestry_of_the_requested_leaf(self):
+        """A sibling branch in the same recordset must not bleed into the path."""
+        records = [
+            region("EU", 0, None),
+            region("NL", 1, "EU"),
+            region("US", 0, None),
+        ]
+        assert build_path("NL", records) == ["EU", "NL"]
+
+    def test_unknown_endpoint_returns_empty(self):
+        assert build_path("nope", [region("EU", 0, None)]) == []
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "build_path finds ancestors by name (tools.py:37). NetBox only "
+            "enforces unique region names at the top level, so a name reused "
+            "under two parents yields two matches; build_path cannot choose and "
+            "returns [] (tools.py:32,35), dropping the whole path. The device "
+            "then lands in the wrong hostgroup with no error -- see the "
+            "functional test test_ambiguous_region_name_still_traverses. Remove "
+            "this marker once build_path disambiguates by parent or id."
+        ),
+    )
+    def test_reused_ancestor_name_still_resolves(self):
+        """`North` under both EU and US should still resolve EU's leaf's path.
+
+        The leaf is unambiguous -- it has one parent -- but its parent's name is
+        not unique across the tree, which is all build_path keys on.
+        """
+        records = [
+            region("EU", 0, None),
+            region("US", 0, None),
+            region("North", 1, "EU"),
+            region("North", 1, "US"),
+            region("Leaf", 2, "North"),
+        ]
+        assert build_path("Leaf", records) == ["EU", "North", "Leaf"]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,4 +1,13 @@
-from netbox_zabbix_sync.modules.tools import sanatize_log_output
+from logging import getLogger
+
+import pytest
+
+from netbox_zabbix_sync.modules.exceptions import JinjaRenderError
+from netbox_zabbix_sync.modules.tools import (
+    field_mapper,
+    jinjafy_config_context,
+    sanatize_log_output,
+)
 
 
 def test_sanatize_log_output_secrets():
@@ -62,3 +71,170 @@ def test_sanatize_log_output_non_dict():
     data = [1, 2, 3]
     sanitized = sanatize_log_output(data)
     assert sanitized == data
+
+
+class DummyNB(dict):
+    """A stand-in for a pynetbox Record.
+
+    Subclasses dict because that is the part of a Record these functions use:
+    field_mapper indexes (`value[item]`), and jinjafy_config_context calls
+    dict() on the object. Attribute access is wired to the same data so
+    `.config_context` and `.name` work like a Record's.
+    """
+
+    def __getattr__(self, item):
+        try:
+            return self[item]
+        except KeyError as e:
+            raise AttributeError(item) from e
+
+
+@pytest.fixture
+def logger():
+    return getLogger(__name__)
+
+
+class TestFieldMapper:
+    """field_mapper walks NetBox fields by name for inventory, macros and tags."""
+
+    def test_maps_top_level_field(self, logger):
+        nb = DummyNB(serial="SN-123")
+        assert field_mapper("host", {"serial": "serialno_a"}, nb, logger) == {
+            "serialno_a": "SN-123"
+        }
+
+    def test_walks_nested_fields_on_the_slash(self, logger):
+        nb = DummyNB(device_type={"manufacturer": {"name": "Acme"}})
+        mapper = {"device_type/manufacturer/name": "vendor"}
+        assert field_mapper("host", mapper, nb, logger) == {"vendor": "Acme"}
+
+    def test_values_are_stringified(self, logger):
+        """Zabbix takes strings, so an int field must be converted, not sent raw."""
+        nb = DummyNB(id=42)
+        assert field_mapper("host", {"id": "{$NB_ID}"}, nb, logger) == {
+            "{$NB_ID}": "42"
+        }
+
+    def test_zero_is_kept_rather_than_treated_as_empty(self, logger):
+        """0 is a value, not an absence -- the reason for the int/float check."""
+        nb = DummyNB(position=0)
+        assert field_mapper("host", {"position": "site_rack"}, nb, logger) == {
+            "site_rack": "0"
+        }
+
+    def test_empty_value_becomes_empty_string(self, logger):
+        """None maps to "", which is what the Zabbix API accepts for a blank."""
+        nb = DummyNB(serial=None)
+        assert field_mapper("host", {"serial": "serialno_a"}, nb, logger) == {
+            "serialno_a": ""
+        }
+
+    def test_empty_nested_parent_stops_the_walk(self, logger):
+        """A null parent short-circuits instead of raising on the child."""
+        nb = DummyNB(virtual_chassis=None)
+        assert field_mapper(
+            "host", {"virtual_chassis/name": "chassis"}, nb, logger
+        ) == {"chassis": ""}
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "field_mapper indexes with value[item] (tools.py:130), so a key NetBox "
+            "did not return raises KeyError instead of mapping to ''. The KeyError "
+            "escapes Sync.start(), which catches SyncError only, and ends the whole "
+            "run. Hit in practice by mapping a field that needs one of the "
+            "extended_* settings without enabling it -- see the functional test "
+            "test_unextended_mapped_field_aborts_the_run. Remove this marker once "
+            "an absent key maps to '' like an empty value already does."
+        ),
+    )
+    def test_absent_field_maps_to_empty_string(self, logger):
+        """An absent key should be treated like an empty value, not raise.
+
+        NetBox serves related objects in a nested form carrying only some of
+        their fields, so "the map names a field this object does not have" is
+        an ordinary condition, not a programming error.
+        """
+        nb = DummyNB(site={"name": "AMS-01"})
+
+        assert field_mapper("host", {"site/latitude": "location_lat"}, nb, logger) == {
+            "location_lat": ""
+        }
+
+
+class TestJinjafyConfigContext:
+    """jinjafy_config_context renders the zabbix key with the object as `data`."""
+
+    def test_renders_a_netbox_field_into_the_context(self):
+        nb = DummyNB(
+            serial="SN-123",
+            config_context={"zabbix": {"usermacros": {"{$S}": "{{ data.serial }}"}}},
+        )
+        assert jinjafy_config_context(nb) == {"usermacros": {"{$S}": "SN-123"}}
+
+    def test_renders_nested_data(self):
+        nb = DummyNB(
+            site={"name": "AMS-01"},
+            config_context={"zabbix": {"tags": [{"site": "{{ data.site.name }}"}]}},
+        )
+        assert jinjafy_config_context(nb) == {"tags": [{"site": "AMS-01"}]}
+
+    def test_config_context_is_not_visible_to_the_template(self):
+        """`data` excludes config_context, so a context cannot template itself.
+
+        Dropped deliberately (tools.py:82-83): leaving it in would let a
+        template read its own unrendered source. Referencing it is not an
+        error, though -- Jinja's default undefined renders as an empty string,
+        so the macro silently comes out blank rather than failing loudly.
+        """
+        nb = DummyNB(config_context={"zabbix": {"x": "{{ data.config_context }}"}})
+
+        assert jinjafy_config_context(nb) == {"x": ""}
+
+    def test_explicit_context_overrides_the_objects_own(self):
+        nb = DummyNB(serial="SN-123", config_context={"zabbix": {"a": "unused"}})
+        assert jinjafy_config_context(nb, context={"b": "{{ data.serial }}"}) == {
+            "b": "SN-123"
+        }
+
+    def test_unknown_filter_raises_jinja_render_error(self):
+        """Jinja's own errors are wrapped, which is what core.py catches."""
+        nb = DummyNB(config_context={"zabbix": {"x": "{{ data | no_such_filter }}"}})
+
+        with pytest.raises(JinjaRenderError):
+            jinjafy_config_context(nb)
+
+    def test_render_producing_invalid_json_raises(self):
+        """The context is rendered as JSON text, so a stray quote is fatal.
+
+        Rendering templates `dumps(context)` and parses the result back, so a
+        value containing a quote breaks the document rather than the value.
+        This is the failure mode users hit with unescaped NetBox comments.
+        """
+        nb = DummyNB(
+            comments='has "quotes"',
+            config_context={"zabbix": {"x": "{{ data.comments }}"}},
+        )
+
+        with pytest.raises(JinjaRenderError):
+            jinjafy_config_context(nb)
+
+    @pytest.mark.parametrize(
+        "config_context",
+        [
+            pytest.param({}, id="no-config-context"),
+            pytest.param({"zabbix": {}}, id="empty-zabbix-key"),
+            pytest.param({"other_app": {"k": "v"}}, id="no-zabbix-key"),
+        ],
+    )
+    def test_returns_empty_dict_when_there_is_nothing_to_render(self, config_context):
+        """The empty render, which the caller cannot tell from a failure.
+
+        Pinned here because this return value is the root of a live bug: an
+        empty dict is falsy, and core.py:211 reads any falsy render as an error
+        and skips the host. So enabling render_config_context stops syncing
+        every device without a zabbix config context -- most of them. See the
+        functional test test_rendering_skips_hosts_with_no_zabbix_context.
+        """
+        nb = DummyNB(config_context=config_context)
+        assert jinjafy_config_context(nb) == {}


### PR DESCRIPTION
Would have left his empty but hey we have this now:

This pull request significantly expands and improves the functional test suite for NetBox/Zabbix integration, with a focus on supporting and testing virtual machines (VMs), enhancing test isolation, and providing more comprehensive coverage of host attribute and mapping features. The changes introduce new fixtures and utilities for VMs, add cluster and cluster type seeding, improve cleanup and test reliability, and document the testing approach in detail.

**Key changes include:**

### VM Support and Cluster Seeding

* Added creation and seeding of `cluster_type` and `cluster` objects in `seed_netbox.py` to support VM tests and the default `vm_hostgroup_format`. Also added a VM-specific Zabbix template (`ZABBIX_VM_TEMPLATE`). [[1]](diffhunk://#diff-f7e4f0e7fd299269d5b1657b5a78ab433229f829f43f1a51c6659726d353a1b3R28-R55) [[2]](diffhunk://#diff-f7e4f0e7fd299269d5b1657b5a78ab433229f829f43f1a51c6659726d353a1b3L74-R112) [[3]](diffhunk://#diff-f7e4f0e7fd299269d5b1657b5a78ab433229f829f43f1a51c6659726d353a1b3R139-R158)
* Introduced the `vm_factory` fixture to create and clean up VMs with appropriate config contexts, cluster, and site assignments. Ensures VMs have the required Zabbix template and are properly removed after tests.

### Test Isolation and Cleanup

* Improved `device_factory` to support additional attributes, such as tags, config context, DNS names, and OOB addresses, and to ensure dependent objects are deleted in the correct order.
* Added the `tag_factory` fixture to create and clean up unique tags per test, preventing tag leakage between tests.
* Added the `virtual_chassis_factory` fixture for creating and cleaning up virtual chassis objects and their associated Zabbix hosts.

### Host Attribute and Mapping Testing

* Documented and implemented comprehensive tests for host attributes, config context, extended properties, and the shipped default mappings. Added explanations and rationale in `README.md` for the new and existing tests, including coverage of xfail markers and their significance. [[1]](diffhunk://#diff-54d1ecde0c29cf42c413c245502d4d8ec2da108bf976b350cb755d81b44862c4L107-R111) [[2]](diffhunk://#diff-54d1ecde0c29cf42c413c245502d4d8ec2da108bf976b350cb755d81b44862c4L157-R260)
* Added utility functions (`tag_pairs`, `macro_values`, `macro_types`) to extract and assert on Zabbix host tags and usermacros in a reliable way.

### Test Runner Enhancements

* Added the `run_vm_sync` fixture to run the sync process scoped to a single VM, ensuring that VM tests do not inadvertently sync devices.
* Improved the `zabbix_host` fixture to always request tags, macros, and inventory from Zabbix, preventing false negatives when asserting on these attributes.

These changes collectively make the test suite more robust, maintainable, and capable of accurately testing both device and VM synchronization scenarios.